### PR TITLE
Check status of the contract deployment operation as integer

### DIFF
--- a/deploy/src/deploymentUtils.js
+++ b/deploy/src/deploymentUtils.js
@@ -46,7 +46,7 @@ async function deployContract(contractJson, args, { from, network, nonce }) {
     url,
     gasPrice: gasPrice
   })
-  if (tx.status !== '0x1') {
+  if (Web3Utils.hexToNumber(tx.status) !== 1) {
     throw new Error('Tx failed')
   }
   instance.options.address = tx.contractAddress


### PR DESCRIPTION
During deployment the bridge contracts to Rootstock network it was found that as part of changes made under https://github.com/poanetwork/poa-bridge-contracts/pull/106 one place was missed.

Since Rootstock network nodes return the status of operation as "0x01" whereas the deployment script expect "0x1", the deployment process fails. 