### PR TITLE
Add method to migrate from SCD to MCD

### DIFF
--- a/contracts/interfaces/IScdMcdMigration.sol
+++ b/contracts/interfaces/IScdMcdMigration.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.4.24;
+
+interface IScdMcdMigration {
+    function swapSaiToDai(uint256 wad) external;
+}

--- a/contracts/interfaces/IScdMcdMigration.sol
+++ b/contracts/interfaces/IScdMcdMigration.sol
@@ -2,4 +2,9 @@ pragma solidity 0.4.24;
 
 interface IScdMcdMigration {
     function swapSaiToDai(uint256 wad) external;
+    function daiJoin() external returns (address);
+}
+
+interface IDaiAdapter {
+    function dai() public returns (address);
 }

--- a/contracts/mocks/DaiAdapterMock.sol
+++ b/contracts/mocks/DaiAdapterMock.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24;
+
+contract DaiAdapterMock {
+    address public dai;
+
+    constructor(address _dai) public {
+        dai = _dai;
+    }
+}

--- a/contracts/mocks/ScdMcdMigrationMock.sol
+++ b/contracts/mocks/ScdMcdMigrationMock.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.4.24;
+
+import "../interfaces/IScdMcdMigration.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
+
+contract ScdMcdMigrationMock is IScdMcdMigration {
+    address public sai;
+    address public dai;
+
+    constructor(address _sai, address _dai) public {
+        sai = _sai;
+        dai = _dai;
+    }
+
+    function swapSaiToDai(uint256 wad) external {
+        ERC20(sai).transferFrom(msg.sender, address(this), wad);
+        MintableToken(dai).mint(msg.sender, wad);
+    }
+}

--- a/contracts/mocks/ScdMcdMigrationMock.sol
+++ b/contracts/mocks/ScdMcdMigrationMock.sol
@@ -6,15 +6,19 @@ import "openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 
 contract ScdMcdMigrationMock is IScdMcdMigration {
     address public sai;
-    address public dai;
+    IDaiAdapter public daiJoin;
 
-    constructor(address _sai, address _dai) public {
+    constructor(address _sai, address _daiJoin) public {
         sai = _sai;
-        dai = _dai;
+        daiJoin = IDaiAdapter(_daiJoin);
     }
 
     function swapSaiToDai(uint256 wad) external {
         ERC20(sai).transferFrom(msg.sender, address(this), wad);
-        MintableToken(dai).mint(msg.sender, wad);
+        MintableToken(daiJoin.dai()).mint(msg.sender, wad);
+    }
+
+    function daiJoin() external returns (address) {
+        return daiJoin;
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -83,12 +83,11 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
         super._relayTokens(_sender, _receiver, _amount);
     }
 
-    function migrateToMCD(address _migrationContract, address _mcdContract) external onlyOwner {
+    function migrateToMCD(address _migrationContract) external onlyOwner {
         bytes32 storageAddress = 0x3378953eb16363e06fd9ea9701d36ed7285d206d9de7df55b778462d74596a89; // keccak256(abi.encodePacked("migrationToMcdCompleted"))
 
         require(!boolStorage[storageAddress]);
         require(AddressUtils.isContract(_migrationContract));
-        require(AddressUtils.isContract(_mcdContract));
 
         uint256 curBalance = erc20token().balanceOf(address(this));
         require(erc20token().approve(_migrationContract, curBalance));
@@ -96,7 +95,8 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
         //event as part of the tokens minting
         IScdMcdMigration(_migrationContract).swapSaiToDai(curBalance);
         address saiContract = erc20token();
-        setErc20token(_mcdContract);
+        address mcdContract = IDaiAdapter(IScdMcdMigration(_migrationContract).daiJoin()).dai();
+        setErc20token(mcdContract);
         require(erc20token().balanceOf(address(this)) == curBalance);
 
         emit TokensSwapped(saiContract, erc20token(), curBalance);

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -3,8 +3,11 @@ pragma solidity 0.4.24;
 import "../BasicForeignBridge.sol";
 import "../ERC20Bridge.sol";
 import "../OtherSideBridgeStorage.sol";
+import "../../interfaces/IScdMcdMigration.sol";
 
 contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideBridgeStorage {
+    event TokensSwapped(address indexed from, address indexed to, uint256 value);
+
     function initialize(
         address _validatorContract,
         address _erc20token,
@@ -78,5 +81,25 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
     function _relayTokens(address _sender, address _receiver, uint256 _amount) internal {
         require(_receiver != bridgeContractOnOtherSide());
         super._relayTokens(_sender, _receiver, _amount);
+    }
+
+    function migrateToMCD(address _migrationContract, address _mcdContract) external onlyOwner {
+        bytes32 storageAddress = 0x3378953eb16363e06fd9ea9701d36ed7285d206d9de7df55b778462d74596a89; // keccak256(abi.encodePacked("migrationToMcdCompleted"))
+
+        require(!boolStorage[storageAddress]);
+        require(AddressUtils.isContract(_migrationContract));
+        require(AddressUtils.isContract(_mcdContract));
+
+        uint256 curBalance = erc20token().balanceOf(address(this));
+        require(erc20token().approve(_migrationContract, curBalance));
+        //It is important to note that this action will cause appearing of `Transfer`
+        //event as part of the tokens minting
+        IScdMcdMigration(_migrationContract).swapSaiToDai(curBalance);
+        address saiContract = erc20token();
+        setErc20token(_mcdContract);
+        require(erc20token().balanceOf(address(this)) == curBalance);
+
+        emit TokensSwapped(saiContract, erc20token(), curBalance);
+        boolStorage[storageAddress] = true;
     }
 }

--- a/test/erc_to_native/foreign_bridge.test.js
+++ b/test/erc_to_native/foreign_bridge.test.js
@@ -3,10 +3,12 @@ const ForeignBridgeV2 = artifacts.require('ForeignBridgeV2.sol')
 const BridgeValidators = artifacts.require('BridgeValidators.sol')
 const EternalStorageProxy = artifacts.require('EternalStorageProxy.sol')
 const ERC677BridgeToken = artifacts.require('ERC677BridgeToken.sol')
+const ERC20Mock = artifacts.require('ERC20Mock.sol')
+const ScdMcdMigrationMock = artifacts.require('ScdMcdMigrationMock.sol')
 
 const { expect } = require('chai')
 const { ERROR_MSG, ZERO_ADDRESS, toBN } = require('../setup')
-const { createMessage, sign, signatureToVRS, ether, expectEventInLogs } = require('../helpers/helpers')
+const { createMessage, sign, signatureToVRS, ether, expectEventInLogs, getEvents } = require('../helpers/helpers')
 
 const halfEther = ether('0.5')
 const requireBlockConfirmations = 8
@@ -832,6 +834,80 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         recipient,
         value
       })
+    })
+  })
+  describe('migrateToMCD', () => {
+    let foreignBridge
+    let sai
+    let dai
+    let migrationContract
+    beforeEach(async () => {
+      foreignBridge = await ForeignBridge.new()
+      sai = await ERC20Mock.new('sai', 'SAI', 18)
+      dai = await ERC20Mock.new('dai', 'DAI', 18)
+      migrationContract = await ScdMcdMigrationMock.new(sai.address, dai.address)
+
+      await foreignBridge.initialize(
+        validatorContract.address,
+        sai.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      )
+
+      // Mint the bridge some sai tokens
+      await sai.mint(foreignBridge.address, oneEther)
+
+      // migration contract can mint dai
+      await dai.transferOwnership(migrationContract.address)
+    })
+    it('should be able to swap tokens', async () => {
+      // Given
+      expect(await sai.balanceOf(foreignBridge.address)).to.be.bignumber.equal(oneEther)
+      expect(await dai.balanceOf(foreignBridge.address)).to.be.bignumber.equal(ZERO)
+      expect(await foreignBridge.erc20token()).to.be.equal(sai.address)
+
+      // When
+
+      // migration address should be a contract
+      await foreignBridge.migrateToMCD(accounts[3], dai.address, { from: owner }).should.be.rejectedWith(ERROR_MSG)
+
+      // dai address should be a contract
+      await foreignBridge
+        .migrateToMCD(migrationContract.address, accounts[4], { from: owner })
+        .should.be.rejectedWith(ERROR_MSG)
+
+      // should be called by owner
+      await foreignBridge
+        .migrateToMCD(migrationContract.address, dai.address, { from: accounts[5] })
+        .should.be.rejectedWith(ERROR_MSG)
+
+      const { logs } = await foreignBridge.migrateToMCD(migrationContract.address, dai.address, { from: owner }).should
+        .be.fulfilled
+
+      // can't migrate token again
+      await foreignBridge
+        .migrateToMCD(migrationContract.address, dai.address, { from: owner })
+        .should.be.rejectedWith(ERROR_MSG)
+
+      // Then
+      expect(await sai.balanceOf(foreignBridge.address)).to.be.bignumber.equal(ZERO)
+      expect(await dai.balanceOf(foreignBridge.address)).to.be.bignumber.equal(oneEther)
+      expect(await foreignBridge.erc20token()).to.be.equal(dai.address)
+      expectEventInLogs(logs, 'TokensSwapped', {
+        from: sai.address,
+        to: dai.address,
+        value: oneEther
+      })
+      const transferEvent = await getEvents(dai, { event: 'Transfer' })
+      expect(transferEvent.length).to.be.equal(1)
+      expect(transferEvent[0].returnValues.from).to.be.equal(ZERO_ADDRESS)
+      expect(transferEvent[0].returnValues.to).to.be.equal(foreignBridge.address)
+      expect(transferEvent[0].returnValues.value).to.be.equal(oneEther.toString())
     })
   })
 })


### PR DESCRIPTION
Closes #310 

Tested the implementation with MakerDAO contracts in Kovan testnet:
- Sai Address: `0xc4375b7de8af5a38a93548eb8453a498222c4ff2`
- Dai Address: `0x1d7e3a1a65a367db1d1d3f51a54ac01a2c4c92ff`
- ScdMcdMigration Address: `0x97cb5a9abcdbe291d0cd85915fa5b08746fe948a`
- [Full list of MakerDAO contracts on Kovan](https://changelog.makerdao.com/releases/kovan/0.2.15/contracts.json) 

Foreign Bridge Address: [`0x61429A7ac9e32531f52C181C15ca453e6f5E9e8B`](https://blockscout.com/eth/kovan/address/0x61429a7ac9e32531f52c181c15ca453e6f5e9e8b)
`migrateToMCD` call: [`0x1a96964024175ce0a93f4da41603f9a8ea173d0e88c84336eee23809013eb8e6`](https://blockscout.com/eth/kovan/tx/0x1a96964024175ce0a93f4da41603f9a8ea173d0e88c84336eee23809013eb8e6)