### PR TITLE
Merge the develop branch to the master branch, preparation to v3.2.0

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -8,6 +8,7 @@
     "no-inline-assembly": "off",
     "multiple-sends": "off",
     "bracket-align": "off",
+    "no-complex-fallback": "off",
     "compiler-version": ["error", "0.4.24"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are two ways to deploy contracts:
 npm install
 ```
 #### Deploy
-Please the [README.md](deploy/README.md) in the `deploy` folder for instructions and .env file configuration
+Please read the [README.md](deploy/README.md) in the `deploy` folder for instructions and .env file configuration
 
 #### Test
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Responsibilities and roles of the bridge:
     - in `ERC-TO-ERC` mode: transfer ERC20 tokens to the Foreign Bridge to mint ERC20 tokens on the Home Network, transfer ERC20 tokens to the Home Bridge to unlock ERC20 tokens on Foreign networks; 
     - in `ERC-TO-NATIVE` mode: send ERC20 tokens to the Foreign Bridge to receive native coins from the Home Bridge, send native coins to the Home Bridge to unlock ERC20 tokens from the Foreign Bridge;
     - in `ARBITRARY-MESSAGE` mode: Invoke Home/Foreign Bridge to send a message that will be executed on the other Network as an arbitrary contract method invocation;
-    - in `AMB-ERC-TO-ERC` mode: transfer ERC20 tokens to the Foreign Mediator which will interact with Foreign AMB Bridge to mint ERC20 tokens on the Home Network, transfer ERC20 tokens to the Home Mediator which will interact with Home AMB Bridge to unlock ERC20 tokens on Foreign network. - in `ARBITRARY-MESSAGE` mode: Invoke Home/Foreign Bridge to send a message that will be executed on the other Network as an arbitrary contract method invocation.
+    - in `AMB-ERC-TO-ERC` mode: transfer ERC20 tokens to the Foreign Mediator which will interact with Foreign AMB Bridge to mint ERC20 tokens on the Home Network, transfer ERC20 tokens to the Home Mediator which will interact with Home AMB Bridge to unlock ERC20 tokens on Foreign network.
 
 ## Usage
 

--- a/contracts/ERC677BridgeToken.sol
+++ b/contracts/ERC677BridgeToken.sol
@@ -38,7 +38,7 @@ contract ERC677BridgeToken is IBurnableMintableERC677Token, DetailedERC20, Burna
     }
 
     function getTokenInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (2, 1, 0);
+        return (2, 2, 0);
     }
 
     function superTransfer(address _to, uint256 _value) internal returns (bool) {

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -33,21 +33,14 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
         _;
     }
 
-    function mintReward(address[] _receivers, uint256[] _rewards) external onlyBlockRewardContract {
-        uint256 receiversLength = _receivers.length;
-        for (uint256 i = 0; i < receiversLength; i++) {
-            uint256 amount = _rewards[i];
-
-            if (amount == 0) continue;
-
-            address to = _receivers[i];
-
-            // Mint `amount` for `to`
-            totalSupply_ = totalSupply_.add(amount);
-            balances[to] = balances[to].add(amount);
-            emit Mint(to, amount);
-            emit Transfer(address(0), to, amount);
-        }
+    function mintReward(uint256 _amount) external onlyBlockRewardContract {
+        if (_amount == 0) return;
+        // Mint `_amount` for the BlockReward contract
+        address to = blockRewardContract;
+        totalSupply_ = totalSupply_.add(_amount);
+        balances[to] = balances[to].add(_amount);
+        emit Mint(to, _amount);
+        emit Transfer(address(0), to, _amount);
     }
 
     function stake(address _staker, uint256 _amount) external onlyStakingContract {
@@ -58,11 +51,13 @@ contract ERC677BridgeTokenRewardable is ERC677BridgeToken {
     }
 
     function transfer(address _to, uint256 _value) public returns (bool) {
+        require(_to != blockRewardContract);
         require(_to != stakingContract);
         return super.transfer(_to, _value);
     }
 
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+        require(_to != blockRewardContract);
         require(_to != stakingContract);
         return super.transferFrom(_from, _to, _value);
     }

--- a/contracts/interfaces/IScdMcdMigration.sol
+++ b/contracts/interfaces/IScdMcdMigration.sol
@@ -1,0 +1,10 @@
+pragma solidity 0.4.24;
+
+interface IScdMcdMigration {
+    function swapSaiToDai(uint256 wad) external;
+    function daiJoin() external returns (address);
+}
+
+interface IDaiAdapter {
+    function dai() public returns (address);
+}

--- a/contracts/libraries/Bytes.sol
+++ b/contracts/libraries/Bytes.sol
@@ -6,4 +6,10 @@ library Bytes {
             result := mload(add(_bytes, 32))
         }
     }
+
+    function bytesToAddress(bytes _bytes) internal pure returns (address addr) {
+        assembly {
+            addr := mload(add(_bytes, 20))
+        }
+    }
 }

--- a/contracts/mocks/BlockReward.sol
+++ b/contracts/mocks/BlockReward.sol
@@ -7,11 +7,12 @@ contract BlockReward {
     using SafeMath for uint256;
 
     address[] public validatorList;
+    uint256[] public validatorRewardList;
     uint256 public mintedCoins = 0;
     uint256 public feeAmount = 0;
     mapping(bytes32 => uint256) internal uintStorage;
     bytes32 internal constant MINTED_TOTALLY_BY_BRIDGE = "mintedTotallyByBridge";
-    bytes4 internal constant MINT_REWARD = 0xe2f764a3; // mintReward(address[],uint256[])
+    bytes4 internal constant MINT_REWARD = 0x91c0aabf; // mintReward(uint256)
     address public token;
 
     function() external payable {
@@ -67,8 +68,7 @@ contract BlockReward {
     }
 
     function addBridgeTokenFeeReceivers(uint256 _amount) external {
-        address[] memory receivers = new address[](validatorList.length);
-        uint256[] memory rewards = new uint256[](validatorList.length);
+        validatorRewardList = new uint256[](validatorList.length);
         feeAmount = _amount;
         uint256 feePerValidator = _amount.div(validatorList.length);
 
@@ -83,11 +83,10 @@ contract BlockReward {
             if (diff > 0 && randomValidatorIndex == i) {
                 feeToDistribute = feeToDistribute.add(diff);
             }
-            receivers[i] = validatorList[i];
-            rewards[i] = feeToDistribute;
+            validatorRewardList[i] = feeToDistribute;
         }
 
-        require(token.call(abi.encodeWithSelector(MINT_REWARD, receivers, rewards)));
+        require(token.call(abi.encodeWithSelector(MINT_REWARD, _amount)));
     }
 
     function random(uint256 _count) public view returns (uint256) {

--- a/contracts/mocks/DaiAdapterMock.sol
+++ b/contracts/mocks/DaiAdapterMock.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24;
+
+contract DaiAdapterMock {
+    address public dai;
+
+    constructor(address _dai) public {
+        dai = _dai;
+    }
+}

--- a/contracts/mocks/FeeManagerMock.sol
+++ b/contracts/mocks/FeeManagerMock.sol
@@ -12,7 +12,7 @@ contract FeeManagerMock is BaseFeeManager {
     }
 
     function getFeeManagerMode() external pure returns (bytes4) {
-        return bytes4(keccak256(abi.encodePacked("manages-one-direction")));
+        return 0xf2aed8f7; // bytes4(keccak256(abi.encodePacked("manages-one-direction")))
     }
 
     function randomTest(uint256 _count) external view returns (uint256) {

--- a/contracts/mocks/ScdMcdMigrationMock.sol
+++ b/contracts/mocks/ScdMcdMigrationMock.sol
@@ -1,0 +1,24 @@
+pragma solidity 0.4.24;
+
+import "../interfaces/IScdMcdMigration.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
+
+contract ScdMcdMigrationMock is IScdMcdMigration {
+    address public sai;
+    IDaiAdapter public daiJoin;
+
+    constructor(address _sai, address _daiJoin) public {
+        sai = _sai;
+        daiJoin = IDaiAdapter(_daiJoin);
+    }
+
+    function swapSaiToDai(uint256 wad) external {
+        ERC20(sai).transferFrom(msg.sender, address(this), wad);
+        MintableToken(daiJoin.dai()).mint(msg.sender, wad);
+    }
+
+    function daiJoin() external returns (address) {
+        return daiJoin;
+    }
+}

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -9,8 +9,8 @@ contract BaseBridgeValidators is InitializableBridge, Ownable {
 
     address public constant F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
     uint256 internal constant MAX_VALIDATORS = 100;
-    bytes32 internal constant REQUIRED_SIGNATURES = keccak256(abi.encodePacked("requiredSignatures"));
-    bytes32 internal constant VALIDATOR_COUNT = keccak256(abi.encodePacked("validatorCount"));
+    bytes32 internal constant REQUIRED_SIGNATURES = 0xd18ea17c351d6834a0e568067fb71804d2a588d5e26d60f792b1c724b1bd53b1; // keccak256(abi.encodePacked("requiredSignatures"))
+    bytes32 internal constant VALIDATOR_COUNT = 0x8656d603d9f985c3483946a92789d52202f49736384ba131cb92f62c4c1aa082; // keccak256(abi.encodePacked("validatorCount"))
 
     event ValidatorAdded(address indexed validator);
     event ValidatorRemoved(address indexed validator);

--- a/contracts/upgradeable_contracts/BaseBridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BaseBridgeValidators.sol
@@ -2,9 +2,9 @@ pragma solidity 0.4.24;
 
 import "./Ownable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "./Initializable.sol";
+import "./InitializableBridge.sol";
 
-contract BaseBridgeValidators is Initializable, Ownable {
+contract BaseBridgeValidators is InitializableBridge, Ownable {
     using SafeMath for uint256;
 
     address public constant F_ADDR = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;

--- a/contracts/upgradeable_contracts/BaseERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/BaseERC677Bridge.sol
@@ -16,19 +16,15 @@ contract BaseERC677Bridge is BasicTokenBridge, ERC677Receiver, ERC677Storage {
         addressStorage[ERC677_TOKEN] = _token;
     }
 
-    function onTokenTransfer(
-        address _from,
-        uint256 _value,
-        bytes /*_data*/
-    ) external returns (bool) {
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns (bool) {
         ERC677 token = erc677token();
         require(msg.sender == address(token));
         require(withinLimit(_value));
         setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_value));
-        bridgeSpecificActionsOnTokenTransfer(token, _from, _value);
+        bridgeSpecificActionsOnTokenTransfer(token, _from, _value, _data);
         return true;
     }
 
     /* solcov ignore next */
-    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value) internal;
+    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value, bytes _data) internal;
 }

--- a/contracts/upgradeable_contracts/BaseERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/BaseERC677Bridge.sol
@@ -5,6 +5,7 @@ import "./BasicTokenBridge.sol";
 import "../interfaces/ERC677.sol";
 import "../interfaces/ERC677Receiver.sol";
 import "./ERC677Storage.sol";
+import "../libraries/Bytes.sol";
 
 contract BaseERC677Bridge is BasicTokenBridge, ERC677Receiver, ERC677Storage {
     function erc677token() public view returns (ERC677) {
@@ -25,6 +26,19 @@ contract BaseERC677Bridge is BasicTokenBridge, ERC677Receiver, ERC677Storage {
         return true;
     }
 
+    function chooseReceiver(address _from, bytes _data) internal view returns (address recipient) {
+        recipient = _from;
+        if (_data.length > 0) {
+            require(_data.length == 20);
+            recipient = Bytes.bytesToAddress(_data);
+            require(recipient != address(0));
+            require(recipient != bridgeContractOnOtherSide());
+        }
+    }
+
     /* solcov ignore next */
     function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value, bytes _data) internal;
+
+    /* solcov ignore next */
+    function bridgeContractOnOtherSide() internal view returns (address);
 }

--- a/contracts/upgradeable_contracts/BaseFeeManager.sol
+++ b/contracts/upgradeable_contracts/BaseFeeManager.sol
@@ -13,8 +13,8 @@ contract BaseFeeManager is EternalStorage, FeeTypes {
 
     // This is not a real fee value but a relative value used to calculate the fee percentage
     uint256 internal constant MAX_FEE = 1 ether;
-    bytes32 internal constant HOME_FEE_STORAGE_KEY = keccak256(abi.encodePacked("homeFee"));
-    bytes32 internal constant FOREIGN_FEE_STORAGE_KEY = keccak256(abi.encodePacked("foreignFee"));
+    bytes32 internal constant HOME_FEE_STORAGE_KEY = 0xc3781f3cec62d28f56efe98358f59c2105504b194242dbcb2cc0806850c306e7; // keccak256(abi.encodePacked("homeFee"))
+    bytes32 internal constant FOREIGN_FEE_STORAGE_KEY = 0x68c305f6c823f4d2fa4140f9cf28d32a1faccf9b8081ff1c2de11cf32c733efc; // keccak256(abi.encodePacked("foreignFee"))
 
     function calculateFee(uint256 _value, bool _recover, bytes32 _feeType) public view returns (uint256) {
         uint256 fee = _feeType == HOME_FEE ? getHomeFee() : getForeignFee();

--- a/contracts/upgradeable_contracts/BaseOverdrawManagement.sol
+++ b/contracts/upgradeable_contracts/BaseOverdrawManagement.sol
@@ -6,7 +6,7 @@ contract BaseOverdrawManagement is EternalStorage {
     event AmountLimitExceeded(address recipient, uint256 value, bytes32 transactionHash);
     event AssetAboveLimitsFixed(bytes32 indexed transactionHash, uint256 value, uint256 remaining);
 
-    bytes32 internal constant OUT_OF_LIMIT_AMOUNT = keccak256(abi.encodePacked("outOfLimitAmount"));
+    bytes32 internal constant OUT_OF_LIMIT_AMOUNT = 0x145286dc85799b6fb9fe322391ba2d95683077b2adf34dd576dedc437e537ba7; // keccak256(abi.encodePacked("outOfLimitAmount"))
 
     function outOfLimitAmount() public view returns (uint256) {
         return uintStorage[OUT_OF_LIMIT_AMOUNT];

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -12,8 +12,8 @@ contract BasicBridge is InitializableBridge, Validatable, Ownable, Upgradeable, 
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
 
-    bytes32 internal constant GAS_PRICE = keccak256(abi.encodePacked("gasPrice"));
-    bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = keccak256(abi.encodePacked("requiredBlockConfirmations"));
+    bytes32 internal constant GAS_PRICE = 0x55b3774520b5993024893d303890baa4e84b1244a43c60034d1ced2d3cf2b04b; // keccak256(abi.encodePacked("gasPrice"))
+    bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
 
     function setGasPrice(uint256 _gasPrice) external onlyOwner {
         require(_gasPrice > 0);

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -1,14 +1,14 @@
 pragma solidity 0.4.24;
 
 import "./Upgradeable.sol";
-import "./Initializable.sol";
+import "./InitializableBridge.sol";
 import "openzeppelin-solidity/contracts/AddressUtils.sol";
 import "./Validatable.sol";
 import "./Ownable.sol";
 import "./Claimable.sol";
 import "./VersionableBridge.sol";
 
-contract BasicBridge is Initializable, Validatable, Ownable, Upgradeable, Claimable, VersionableBridge {
+contract BasicBridge is InitializableBridge, Validatable, Ownable, Upgradeable, Claimable, VersionableBridge {
     event GasPriceChanged(uint256 gasPrice);
     event RequiredBlockConfirmationChanged(uint256 requiredBlockConfirmations);
 

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./Validatable.sol";
 import "../libraries/Message.sol";
 import "./BasicTokenBridge.sol";
@@ -13,6 +13,8 @@ import "./MessageRelay.sol";
 contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge, BasicTokenBridge, MessageRelay {
     /// triggered when relay of deposit from HomeBridge is complete
     event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
+    event UserRequestForAffirmation(address recipient, uint256 value);
+
     function executeSignatures(uint8[] vs, bytes32[] rs, bytes32[] ss, bytes message) external {
         Message.hasEnoughValidSignatures(message, vs, rs, ss, validatorContract(), false);
         address recipient;

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./Validatable.sol";
 import "../libraries/Message.sol";
 import "./BasicBridge.sol";

--- a/contracts/upgradeable_contracts/BasicTokenBridge.sol
+++ b/contracts/upgradeable_contracts/BasicTokenBridge.sol
@@ -10,12 +10,12 @@ contract BasicTokenBridge is EternalStorage, Ownable {
     event DailyLimitChanged(uint256 newLimit);
     event ExecutionDailyLimitChanged(uint256 newLimit);
 
-    bytes32 internal constant MIN_PER_TX = keccak256(abi.encodePacked("minPerTx"));
-    bytes32 internal constant MAX_PER_TX = keccak256(abi.encodePacked("maxPerTx"));
-    bytes32 internal constant DAILY_LIMIT = keccak256(abi.encodePacked("dailyLimit"));
-    bytes32 internal constant EXECUTION_MAX_PER_TX = keccak256(abi.encodePacked("executionMaxPerTx"));
-    bytes32 internal constant EXECUTION_DAILY_LIMIT = keccak256(abi.encodePacked("executionDailyLimit"));
-    bytes32 internal constant DECIMAL_SHIFT = keccak256(abi.encodePacked("decimalShift"));
+    bytes32 internal constant MIN_PER_TX = 0xbbb088c505d18e049d114c7c91f11724e69c55ad6c5397e2b929e68b41fa05d1; // keccak256(abi.encodePacked("minPerTx"))
+    bytes32 internal constant MAX_PER_TX = 0x0f8803acad17c63ee38bf2de71e1888bc7a079a6f73658e274b08018bea4e29c; // keccak256(abi.encodePacked("maxPerTx"))
+    bytes32 internal constant DAILY_LIMIT = 0x4a6a899679f26b73530d8cf1001e83b6f7702e04b6fdb98f3c62dc7e47e041a5; // keccak256(abi.encodePacked("dailyLimit"))
+    bytes32 internal constant EXECUTION_MAX_PER_TX = 0xc0ed44c192c86d1cc1ba51340b032c2766b4a2b0041031de13c46dd7104888d5; // keccak256(abi.encodePacked("executionMaxPerTx"))
+    bytes32 internal constant EXECUTION_DAILY_LIMIT = 0x21dbcab260e413c20dc13c28b7db95e2b423d1135f42bb8b7d5214a92270d237; // keccak256(abi.encodePacked("executionDailyLimit"))
+    bytes32 internal constant DECIMAL_SHIFT = 0x1e8ecaafaddea96ed9ac6d2642dcdfe1bebe58a930b1085842d8fc122b371ee5; // keccak256(abi.encodePacked("decimalShift"))
 
     function totalSpentPerDay(uint256 _day) public view returns (uint256) {
         return uintStorage[keccak256(abi.encodePacked("totalSpentPerDay", _day))];

--- a/contracts/upgradeable_contracts/BlockRewardBridge.sol
+++ b/contracts/upgradeable_contracts/BlockRewardBridge.sol
@@ -5,7 +5,7 @@ import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/AddressUtils.sol";
 
 contract BlockRewardBridge is EternalStorage {
-    bytes32 internal constant BLOCK_REWARD_CONTRACT = keccak256(abi.encodePacked("blockRewardContract"));
+    bytes32 internal constant BLOCK_REWARD_CONTRACT = 0x20ae0b8a761b32f3124efb075f427dd6ca669e88ae7747fec9fd1ad688699f32; // keccak256(abi.encodePacked("blockRewardContract"))
     bytes4 internal constant BLOCK_REWARD_CONTRACT_ID = 0x2ee57f8d; // blockRewardContractId()
     bytes4 internal constant BRIDGES_ALLOWED_LENGTH = 0x10f2ee7c; // bridgesAllowedLength()
 

--- a/contracts/upgradeable_contracts/Claimable.sol
+++ b/contracts/upgradeable_contracts/Claimable.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./Sacrifice.sol";
 
 contract Claimable {

--- a/contracts/upgradeable_contracts/ERC20Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC20Bridge.sol
@@ -1,14 +1,14 @@
 pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/AddressUtils.sol";
 
 contract ERC20Bridge is EternalStorage {
     bytes32 internal constant ERC20_TOKEN = 0x15d63b18dbc21bf4438b7972d80076747e1d93c4f87552fe498c90cbde51665e; // keccak256(abi.encodePacked("erc20token"))
 
-    function erc20token() public view returns (ERC20Basic) {
-        return ERC20Basic(addressStorage[ERC20_TOKEN]);
+    function erc20token() public view returns (ERC20) {
+        return ERC20(addressStorage[ERC20_TOKEN]);
     }
 
     function setErc20token(address _token) internal {

--- a/contracts/upgradeable_contracts/ERC20Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC20Bridge.sol
@@ -5,7 +5,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
 import "openzeppelin-solidity/contracts/AddressUtils.sol";
 
 contract ERC20Bridge is EternalStorage {
-    bytes32 internal constant ERC20_TOKEN = keccak256(abi.encodePacked("erc20token"));
+    bytes32 internal constant ERC20_TOKEN = 0x15d63b18dbc21bf4438b7972d80076747e1d93c4f87552fe498c90cbde51665e; // keccak256(abi.encodePacked("erc20token"))
 
     function erc20token() public view returns (ERC20Basic) {
         return ERC20Basic(addressStorage[ERC20_TOKEN]);

--- a/contracts/upgradeable_contracts/ERC20Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC20Bridge.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.4.24;
 
-import "../upgradeability/EternalStorage.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/AddressUtils.sol";
+import "./BasicForeignBridge.sol";
 
-contract ERC20Bridge is EternalStorage {
+contract ERC20Bridge is BasicForeignBridge {
     bytes32 internal constant ERC20_TOKEN = 0x15d63b18dbc21bf4438b7972d80076747e1d93c4f87552fe498c90cbde51665e; // keccak256(abi.encodePacked("erc20token"))
 
     function erc20token() public view returns (ERC20) {
@@ -14,5 +14,25 @@ contract ERC20Bridge is EternalStorage {
     function setErc20token(address _token) internal {
         require(AddressUtils.isContract(_token));
         addressStorage[ERC20_TOKEN] = _token;
+    }
+
+    function _relayTokens(address _sender, address _receiver, uint256 _amount) internal {
+        require(_receiver != address(0));
+        require(_receiver != address(this));
+        require(_amount > 0);
+        require(withinLimit(_amount));
+        setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_amount));
+
+        erc20token().transferFrom(_sender, address(this), _amount);
+        emit UserRequestForAffirmation(_receiver, _amount);
+    }
+
+    function relayTokens(address _from, address _receiver, uint256 _amount) external {
+        require(_from == msg.sender || _from == _receiver);
+        _relayTokens(_from, _receiver, _amount);
+    }
+
+    function relayTokens(address _receiver, uint256 _amount) external {
+        _relayTokens(msg.sender, _receiver, _amount);
     }
 }

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -6,7 +6,8 @@ contract ERC677Bridge is BaseERC677Bridge {
     function bridgeSpecificActionsOnTokenTransfer(
         ERC677, /*_token*/
         address _from,
-        uint256 _value
+        uint256 _value,
+        bytes /*_data*/
     ) internal {
         fireEventOnTokenTransfer(_from, _value);
     }

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -8,9 +8,9 @@ contract ERC677Bridge is BaseERC677Bridge, OtherSideBridgeStorage {
         ERC677, /*_token*/
         address _from,
         uint256 _value,
-        bytes /*_data*/
+        bytes _data
     ) internal {
-        fireEventOnTokenTransfer(_from, _value);
+        fireEventOnTokenTransfer(chooseReceiver(_from, _data), _value);
     }
 
     /* solcov ignore next */

--- a/contracts/upgradeable_contracts/ERC677Bridge.sol
+++ b/contracts/upgradeable_contracts/ERC677Bridge.sol
@@ -1,8 +1,9 @@
 pragma solidity 0.4.24;
 
 import "./BaseERC677Bridge.sol";
+import "./OtherSideBridgeStorage.sol";
 
-contract ERC677Bridge is BaseERC677Bridge {
+contract ERC677Bridge is BaseERC677Bridge, OtherSideBridgeStorage {
     function bridgeSpecificActionsOnTokenTransfer(
         ERC677, /*_token*/
         address _from,

--- a/contracts/upgradeable_contracts/ERC677BridgeForBurnableMintableToken.sol
+++ b/contracts/upgradeable_contracts/ERC677BridgeForBurnableMintableToken.sol
@@ -4,7 +4,12 @@ import "./ERC677Bridge.sol";
 import "../interfaces/IBurnableMintableERC677Token.sol";
 
 contract ERC677BridgeForBurnableMintableToken is ERC677Bridge {
-    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value) internal {
+    function bridgeSpecificActionsOnTokenTransfer(
+        ERC677 _token,
+        address _from,
+        uint256 _value,
+        bytes /*_data*/
+    ) internal {
         IBurnableMintableERC677Token(_token).burn(_value);
         fireEventOnTokenTransfer(_from, _value);
     }

--- a/contracts/upgradeable_contracts/ERC677BridgeForBurnableMintableToken.sol
+++ b/contracts/upgradeable_contracts/ERC677BridgeForBurnableMintableToken.sol
@@ -4,13 +4,8 @@ import "./ERC677Bridge.sol";
 import "../interfaces/IBurnableMintableERC677Token.sol";
 
 contract ERC677BridgeForBurnableMintableToken is ERC677Bridge {
-    function bridgeSpecificActionsOnTokenTransfer(
-        ERC677 _token,
-        address _from,
-        uint256 _value,
-        bytes /*_data*/
-    ) internal {
+    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value, bytes _data) internal {
         IBurnableMintableERC677Token(_token).burn(_value);
-        fireEventOnTokenTransfer(_from, _value);
+        fireEventOnTokenTransfer(chooseReceiver(_from, _data), _value);
     }
 }

--- a/contracts/upgradeable_contracts/ERC677Storage.sol
+++ b/contracts/upgradeable_contracts/ERC677Storage.sol
@@ -1,5 +1,5 @@
 pragma solidity 0.4.24;
 
 contract ERC677Storage {
-    bytes32 internal constant ERC677_TOKEN = keccak256(abi.encodePacked("erc677token"));
+    bytes32 internal constant ERC677_TOKEN = 0xa8b0ade3e2b734f043ce298aca4cc8d19d74270223f34531d0988b7d00cba21d; // keccak256(abi.encodePacked("erc677token"))
 }

--- a/contracts/upgradeable_contracts/FeeTypes.sol
+++ b/contracts/upgradeable_contracts/FeeTypes.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
 contract FeeTypes {
-    bytes32 internal constant HOME_FEE = keccak256(abi.encodePacked("home-fee"));
-    bytes32 internal constant FOREIGN_FEE = keccak256(abi.encodePacked("foreign-fee"));
+    bytes32 internal constant HOME_FEE = 0x89d93e5e92f7e37e490c25f0e50f7f4aad7cc94b308a566553280967be38bcf1; // keccak256(abi.encodePacked("home-fee"))
+    bytes32 internal constant FOREIGN_FEE = 0xdeb7f3adca07d6d1f708c1774389db532a2b2f18fd05a62b957e4089f4696ed5; // keccak256(abi.encodePacked("foreign-fee"))
 }

--- a/contracts/upgradeable_contracts/Initializable.sol
+++ b/contracts/upgradeable_contracts/Initializable.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 import "../upgradeability/EternalStorage.sol";
 
 contract Initializable is EternalStorage {
-    bytes32 internal constant INITIALIZED = keccak256(abi.encodePacked("isInitialized"));
+    bytes32 internal constant INITIALIZED = 0x0a6f646cd611241d8073675e00d1a1ff700fbf1b53fcf473de56d1e6e4b714ba; // keccak256(abi.encodePacked("isInitialized"))
 
     function setInitialize() internal {
         boolStorage[INITIALIZED] = true;

--- a/contracts/upgradeable_contracts/Initializable.sol
+++ b/contracts/upgradeable_contracts/Initializable.sol
@@ -4,7 +4,6 @@ import "../upgradeability/EternalStorage.sol";
 
 contract Initializable is EternalStorage {
     bytes32 internal constant INITIALIZED = keccak256(abi.encodePacked("isInitialized"));
-    bytes32 internal constant DEPLOYED_AT_BLOCK = keccak256(abi.encodePacked("deployedAtBlock"));
 
     function setInitialize() internal {
         boolStorage[INITIALIZED] = true;
@@ -12,9 +11,5 @@ contract Initializable is EternalStorage {
 
     function isInitialized() public view returns (bool) {
         return boolStorage[INITIALIZED];
-    }
-
-    function deployedAtBlock() external view returns (uint256) {
-        return uintStorage[DEPLOYED_AT_BLOCK];
     }
 }

--- a/contracts/upgradeable_contracts/InitializableBridge.sol
+++ b/contracts/upgradeable_contracts/InitializableBridge.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.4.24;
+
+import "./Initializable.sol";
+
+contract InitializableBridge is Initializable {
+    bytes32 internal constant DEPLOYED_AT_BLOCK = keccak256(abi.encodePacked("deployedAtBlock"));
+
+    function deployedAtBlock() external view returns (uint256) {
+        return uintStorage[DEPLOYED_AT_BLOCK];
+    }
+}

--- a/contracts/upgradeable_contracts/InitializableBridge.sol
+++ b/contracts/upgradeable_contracts/InitializableBridge.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 import "./Initializable.sol";
 
 contract InitializableBridge is Initializable {
-    bytes32 internal constant DEPLOYED_AT_BLOCK = 0xb120ceec05576ad0c710bc6e85f1768535e27554458f05dcbb5c65b8c7a749b0; // keccak256(abi.encodePacked("deployedAtBlock"));
+    bytes32 internal constant DEPLOYED_AT_BLOCK = 0xb120ceec05576ad0c710bc6e85f1768535e27554458f05dcbb5c65b8c7a749b0; // keccak256(abi.encodePacked("deployedAtBlock"))
 
     function deployedAtBlock() external view returns (uint256) {
         return uintStorage[DEPLOYED_AT_BLOCK];

--- a/contracts/upgradeable_contracts/InitializableBridge.sol
+++ b/contracts/upgradeable_contracts/InitializableBridge.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 import "./Initializable.sol";
 
 contract InitializableBridge is Initializable {
-    bytes32 internal constant DEPLOYED_AT_BLOCK = keccak256(abi.encodePacked("deployedAtBlock"));
+    bytes32 internal constant DEPLOYED_AT_BLOCK = 0xb120ceec05576ad0c710bc6e85f1768535e27554458f05dcbb5c65b8c7a749b0; // keccak256(abi.encodePacked("deployedAtBlock"));
 
     function deployedAtBlock() external view returns (uint256) {
         return uintStorage[DEPLOYED_AT_BLOCK];

--- a/contracts/upgradeable_contracts/OtherSideBridgeStorage.sol
+++ b/contracts/upgradeable_contracts/OtherSideBridgeStorage.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.4.24;
+
+import "../upgradeability/EternalStorage.sol";
+
+contract OtherSideBridgeStorage is EternalStorage {
+    bytes32 internal constant BRIDGE_CONTRACT = 0x71483949fe7a14d16644d63320f24d10cf1d60abecc30cc677a340e82b699dd2; // keccak256(abi.encodePacked("bridgeOnOtherSide"))
+
+    function _setBridgeContractOnOtherSide(address _bridgeContract) internal {
+        addressStorage[BRIDGE_CONTRACT] = _bridgeContract;
+    }
+
+    function bridgeContractOnOtherSide() internal view returns (address) {
+        return addressStorage[BRIDGE_CONTRACT];
+    }
+}

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -23,12 +23,14 @@ contract Ownable is EternalStorage {
         _;
     }
 
+    bytes32 internal constant OWNER = 0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0; // keccak256(abi.encodePacked("owner"))
+
     /**
     * @dev Tells the address of the owner
     * @return the address of the owner
     */
     function owner() public view returns (address) {
-        return addressStorage[keccak256(abi.encodePacked("owner"))];
+        return addressStorage[OWNER];
     }
 
     /**
@@ -45,6 +47,6 @@ contract Ownable is EternalStorage {
     */
     function setOwner(address newOwner) internal {
         emit OwnershipTransferred(owner(), newOwner);
-        addressStorage[keccak256(abi.encodePacked("owner"))] = newOwner;
+        addressStorage[OWNER] = newOwner;
     }
 }

--- a/contracts/upgradeable_contracts/ReentrancyGuard.sol
+++ b/contracts/upgradeable_contracts/ReentrancyGuard.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 import "../upgradeability/EternalStorage.sol";
 
 contract ReentrancyGuard is EternalStorage {
-    bytes32 internal constant LOCK = keccak256(abi.encodePacked("lock"));
+    bytes32 internal constant LOCK = 0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92; // keccak256(abi.encodePacked("lock"))
 
     function lock() internal returns (bool) {
         return boolStorage[LOCK];

--- a/contracts/upgradeable_contracts/RewardableBridge.sol
+++ b/contracts/upgradeable_contracts/RewardableBridge.sol
@@ -8,7 +8,7 @@ contract RewardableBridge is Ownable, FeeTypes {
     event FeeDistributedFromAffirmation(uint256 feeAmount, bytes32 indexed transactionHash);
     event FeeDistributedFromSignatures(uint256 feeAmount, bytes32 indexed transactionHash);
 
-    bytes32 internal constant FEE_MANAGER_CONTRACT = keccak256(abi.encodePacked("feeManagerContract"));
+    bytes32 internal constant FEE_MANAGER_CONTRACT = 0x779a349c5bee7817f04c960f525ee3e2f2516078c38c68a3149787976ee837e5; // keccak256(abi.encodePacked("feeManagerContract"))
     bytes4 internal constant GET_HOME_FEE = 0x94da17cd; // getHomeFee()
     bytes4 internal constant GET_FOREIGN_FEE = 0xffd66196; // getForeignFee()
     bytes4 internal constant GET_FEE_MANAGER_MODE = 0xf2ba9561; // getFeeManagerMode()

--- a/contracts/upgradeable_contracts/ValidatorStorage.sol
+++ b/contracts/upgradeable_contracts/ValidatorStorage.sol
@@ -1,5 +1,5 @@
 pragma solidity 0.4.24;
 
 contract ValidatorStorage {
-    bytes32 internal constant VALIDATOR_CONTRACT = keccak256(abi.encodePacked("validatorContract"));
+    bytes32 internal constant VALIDATOR_CONTRACT = 0x5a74bb7e202fb8e4bf311841c7d64ec19df195fee77d7e7ae749b27921b6ddfe; // keccak256(abi.encodePacked("validatorContract"))
 }

--- a/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
+++ b/contracts/upgradeable_contracts/ValidatorsFeeManager.sol
@@ -5,13 +5,8 @@ import "../interfaces/IRewardableValidators.sol";
 import "./ValidatorStorage.sol";
 
 contract ValidatorsFeeManager is BaseFeeManager, ValidatorStorage {
-    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_HOME = keccak256(
-        abi.encodePacked("reward-transferring-from-home")
-    );
-
-    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_FOREIGN = keccak256(
-        abi.encodePacked("reward-transferring-from-foreign")
-    );
+    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_HOME = 0x2a11db67c480122765825a7e4bc5428e8b7b9eca0d4e62b91aac194f99edd0d7; // keccak256(abi.encodePacked("reward-transferring-from-home"))
+    bytes32 public constant REWARD_FOR_TRANSFERRING_FROM_FOREIGN = 0xb14796d751eb4f2570065a479f9e526eabeb2077c564c8a1c5ea559883ea2fab; // keccak256(abi.encodePacked("reward-transferring-from-foreign"))
 
     function distributeFeeFromAffirmation(uint256 _fee) external {
         distributeFeeProportionally(_fee, REWARD_FOR_TRANSFERRING_FROM_FOREIGN);

--- a/contracts/upgradeable_contracts/VersionableBridge.sol
+++ b/contracts/upgradeable_contracts/VersionableBridge.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 contract VersionableBridge {
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (2, 3, 0);
+        return (2, 4, 0);
     }
 
     /* solcov ignore next */

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -47,7 +47,6 @@ contract BasicAMBErc677ToErc677 is
         );
         require(_executionDailyLimitExecutionMaxPerTxArray[1] < _executionDailyLimitExecutionMaxPerTxArray[0]); // _executionMaxPerTx < _executionDailyLimit
 
-        uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         _setBridgeContract(_bridgeContract);
         _setMediatorContractOnOtherSide(_mediatorContract);
         setErc677token(_erc677token);

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -24,10 +24,10 @@ contract BasicAMBErc677ToErc677 is
 {
     event FailedMessageFixed(bytes32 indexed dataHash, address recipient, uint256 value);
 
-    bytes32 internal constant BRIDGE_CONTRACT = keccak256(abi.encodePacked("bridgeContract"));
-    bytes32 internal constant MEDIATOR_CONTRACT = keccak256(abi.encodePacked("mediatorContract"));
-    bytes32 internal constant REQUEST_GAS_LIMIT = keccak256(abi.encodePacked("requestGasLimit"));
-    bytes32 internal constant NONCE = keccak256(abi.encodePacked("nonce"));
+    bytes32 internal constant BRIDGE_CONTRACT = 0x811bbb11e8899da471f0e69a3ed55090fc90215227fc5fb1cb0d6e962ea7b74f; // keccak256(abi.encodePacked("bridgeContract"))
+    bytes32 internal constant MEDIATOR_CONTRACT = 0x98aa806e31e94a687a31c65769cb99670064dd7f5a87526da075c5fb4eab9880; // keccak256(abi.encodePacked("mediatorContract"))
+    bytes32 internal constant REQUEST_GAS_LIMIT = 0x2dfd6c9f781bb6bbb5369c114e949b69ebb440ef3d4dd6b2836225eb1dc3a2be; // keccak256(abi.encodePacked("requestGasLimit"))
+    bytes32 internal constant NONCE = 0x7ab1577440dd7bedf920cb6de2f9fc6bf7ba98c78c85a3fa1f8311aac95e1759; // keccak256(abi.encodePacked("nonce"))
 
     function initialize(
         address _bridgeContract,
@@ -101,7 +101,7 @@ contract BasicAMBErc677ToErc677 is
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("erc-to-erc-amb")));
+        return 0x76595b56; // bytes4(keccak256(abi.encodePacked("erc-to-erc-amb")))
     }
 
     function setBridgeContract(address _bridgeContract) external onlyOwner {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -67,6 +67,16 @@ contract BasicAMBErc677ToErc677 is
         return isInitialized();
     }
 
+    function chooseReceiver(address _from, bytes _data) internal view returns (address recipient) {
+        recipient = _from;
+        if (_data.length > 0) {
+            require(_data.length == 20);
+            recipient = Bytes.bytesToAddress(_data);
+            require(recipient != address(0));
+            require(recipient != mediatorContractOnOtherSide());
+        }
+    }
+
     function passMessage(address _from, uint256 _value) internal {
         bytes4 methodSelector = this.handleBridgedTokens.selector;
         bytes memory data = abi.encodeWithSelector(methodSelector, _from, _value, nonce());
@@ -79,21 +89,29 @@ contract BasicAMBErc677ToErc677 is
         bridgeContract().requireToPassMessage(mediatorContractOnOtherSide(), data, requestGasLimit());
     }
 
-    function relayTokens(uint256 _value) external {
+    function relayTokens(address _from, address _receiver, uint256 _value) external {
+        require(_from == msg.sender || _from == _receiver);
+        _relayTokens(_from, _receiver, _value);
+    }
+
+    function _relayTokens(address _from, address _receiver, uint256 _value) internal {
         // This lock is to prevent calling passMessage twice if a ERC677 token is used.
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
         // which will call passMessage.
         require(!lock());
         ERC677 token = erc677token();
-        address from = msg.sender;
         address to = address(this);
         require(withinLimit(_value));
         setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_value));
 
         setLock(true);
-        token.transferFrom(from, to, _value);
+        token.transferFrom(_from, to, _value);
         setLock(false);
-        bridgeSpecificActionsOnTokenTransfer(token, from, _value);
+        bridgeSpecificActionsOnTokenTransfer(token, _from, _value, abi.encodePacked(_receiver));
+    }
+
+    function relayTokens(address _receiver, uint256 _value) external {
+        _relayTokens(msg.sender, _receiver, _value);
     }
 
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -67,14 +67,8 @@ contract BasicAMBErc677ToErc677 is
         return isInitialized();
     }
 
-    function chooseReceiver(address _from, bytes _data) internal view returns (address recipient) {
-        recipient = _from;
-        if (_data.length > 0) {
-            require(_data.length == 20);
-            recipient = Bytes.bytesToAddress(_data);
-            require(recipient != address(0));
-            require(recipient != mediatorContractOnOtherSide());
-        }
+    function bridgeContractOnOtherSide() internal view returns (address) {
+        return mediatorContractOnOtherSide();
     }
 
     function passMessage(address _from, uint256 _value) internal {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -108,6 +108,17 @@ contract BasicAMBErc677ToErc677 is
         _relayTokens(msg.sender, _receiver, _value);
     }
 
+    function onTokenTransfer(address _from, uint256 _value, bytes _data) external returns (bool) {
+        ERC677 token = erc677token();
+        require(msg.sender == address(token));
+        if (!lock()) {
+            require(withinLimit(_value));
+            setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_value));
+        }
+        bridgeSpecificActionsOnTokenTransfer(token, _from, _value, _data);
+        return true;
+    }
+
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
         return (1, 0, 0);
     }

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -120,7 +120,7 @@ contract BasicAMBErc677ToErc677 is
     }
 
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 0, 0);
+        return (1, 1, 0);
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
@@ -13,10 +13,11 @@ contract ForeignAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
     function bridgeSpecificActionsOnTokenTransfer(
         ERC677, /* _token */
         address _from,
-        uint256 _value
+        uint256 _value,
+        bytes _data
     ) internal {
         if (!lock()) {
-            passMessage(_from, _value);
+            passMessage(chooseReceiver(_from, _data), _value);
         }
     }
 

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
@@ -1,8 +1,6 @@
 pragma solidity 0.4.24;
 
 import "./BasicAMBErc677ToErc677.sol";
-import "../ERC677Bridge.sol";
-import "openzeppelin-solidity/contracts/AddressUtils.sol";
 
 contract ForeignAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
     function executeActionOnBridgedTokens(address _recipient, uint256 _value) internal {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeAMBErc677ToErc677.sol
@@ -2,7 +2,6 @@ pragma solidity 0.4.24;
 
 import "./BasicAMBErc677ToErc677.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
-import "openzeppelin-solidity/contracts/AddressUtils.sol";
 
 contract HomeAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
     function executeActionOnBridgedTokens(address _recipient, uint256 _value) internal {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeAMBErc677ToErc677.sol
@@ -10,10 +10,10 @@ contract HomeAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
         IBurnableMintableERC677Token(erc677token()).mint(_recipient, value);
     }
 
-    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value) internal {
+    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value, bytes _data) internal {
         if (!lock()) {
             IBurnableMintableERC677Token(_token).burn(_value);
-            passMessage(_from, _value);
+            passMessage(chooseReceiver(_from, _data), _value);
         }
     }
 

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.24;
 import "../BasicBridge.sol";
 
 contract BasicAMB is BasicBridge {
-    bytes32 internal constant MAX_GAS_PER_TX = keccak256(abi.encodePacked("maxGasPerTx"));
+    bytes32 internal constant MAX_GAS_PER_TX = 0x2670ecc91ec356e32067fd27b36614132d727b84a1e03e08f412a4f2cf075974; // keccak256(abi.encodePacked("maxGasPerTx"))
 
     function initialize(
         address _validatorContract,
@@ -32,7 +32,7 @@ contract BasicAMB is BasicBridge {
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("arbitrary-message-bridge-core")));
+        return 0x2544fbb9; // bytes4(keccak256(abi.encodePacked("arbitrary-message-bridge-core")))
     }
 
     function maxGasPerTx() public view returns (uint256) {

--- a/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
@@ -4,8 +4,8 @@ import "../../upgradeability/EternalStorage.sol";
 import "../../libraries/Bytes.sol";
 
 contract MessageProcessor is EternalStorage {
-    bytes32 internal constant MESSAGE_SENDER = keccak256(abi.encodePacked("messageSender"));
-    bytes32 internal constant TRANSACTION_HASH = keccak256(abi.encodePacked("transactionHash"));
+    bytes32 internal constant MESSAGE_SENDER = 0x7b58b2a669d8e0992eae9eaef641092c0f686fd31070e7236865557fa1571b5b; // keccak256(abi.encodePacked("messageSender"))
+    bytes32 internal constant TRANSACTION_HASH = 0x7bce44346b9831b0c81437a092605c6fc51612016e2c51e62f21d829e434bcf6; // keccak256(abi.encodePacked("transactionHash"))
 
     function messageCallStatus(bytes32 _txHash) external view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("messageCallStatus", _txHash))];

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
 import "../BasicForeignBridge.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
 contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     function _initialize(
@@ -61,7 +61,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     }
 
     /* solcov ignore next */
-    function erc20token() public view returns (ERC20Basic);
+    function erc20token() public view returns (ERC20);
 
     /* solcov ignore next */
     function setErc20token(address _token) internal;

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -38,7 +38,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
+        return 0xba4690f5; // bytes4(keccak256(abi.encodePacked("erc-to-erc-core")))
     }
 
     function claimTokens(address _token, address _to) public {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -4,7 +4,7 @@ import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
     function getFeeManagerMode() external pure returns (bytes4) {
-        return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
+        return 0xd7de965f; // bytes4(keccak256(abi.encodePacked("manages-both-directions")))
     }
 
     function blockRewardContract() external view returns (address) {

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -43,7 +43,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         return isInitialized();
     }
 
-    function erc20token() public view returns (ERC20Basic) {
+    function erc20token() public view returns (ERC20) {
         return erc677token();
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -4,8 +4,6 @@ import "./BasicForeignBridgeErcToErc.sol";
 import "../ERC677Bridge.sol";
 
 contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc {
-    event UserRequestForAffirmation(address recipient, uint256 value);
-
     function initialize(
         address _validatorContract,
         address _erc20token,
@@ -16,29 +14,16 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         address _owner,
         uint256 _decimalShift
     ) external returns (bool) {
-        require(
-            _dailyLimitMaxPerTxMinPerTxArray[2] > 0 && // _minPerTx > 0
-                _dailyLimitMaxPerTxMinPerTxArray[1] > _dailyLimitMaxPerTxMinPerTxArray[2] && // _maxPerTx > _minPerTx
-                _dailyLimitMaxPerTxMinPerTxArray[0] > _dailyLimitMaxPerTxMinPerTxArray[1] // _dailyLimit > _maxPerTx
-        );
-        uint256[] memory _maxPerTxHomeDailyLimitHomeMaxPerTxArray = new uint256[](3);
-        _maxPerTxHomeDailyLimitHomeMaxPerTxArray[0] = _dailyLimitMaxPerTxMinPerTxArray[1]; // _maxPerTx
-        _maxPerTxHomeDailyLimitHomeMaxPerTxArray[1] = _homeDailyLimitHomeMaxPerTxArray[0]; // _homeDailyLimit
-        _maxPerTxHomeDailyLimitHomeMaxPerTxArray[2] = _homeDailyLimitHomeMaxPerTxArray[1]; // _homeMaxPerTx
         _initialize(
             _validatorContract,
             _erc20token,
             _requiredBlockConfirmations,
             _gasPrice,
-            _maxPerTxHomeDailyLimitHomeMaxPerTxArray, // [ 0 = _maxPerTx, 1 = _homeDailyLimit, 2 = _homeMaxPerTx ]
+            _dailyLimitMaxPerTxMinPerTxArray,
+            _homeDailyLimitHomeMaxPerTxArray,
             _owner,
             _decimalShift
         );
-
-        uintStorage[DAILY_LIMIT] = _dailyLimitMaxPerTxMinPerTxArray[0];
-        uintStorage[MIN_PER_TX] = _dailyLimitMaxPerTxMinPerTxArray[2];
-
-        emit DailyLimitChanged(_dailyLimitMaxPerTxMinPerTxArray[0]);
 
         return isInitialized();
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -9,7 +9,8 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc, ERC20Bridge {
         address _erc20token,
         uint256 _requiredBlockConfirmations,
         uint256 _gasPrice,
-        uint256[] _maxPerTxHomeDailyLimitHomeMaxPerTxArray, // [ 0 = _maxPerTx, 1 = _homeDailyLimit, 2 = _homeMaxPerTx ]
+        uint256[] _dailyLimitMaxPerTxMinPerTxArray, // [ 0 = _dailyLimit, 1 = _maxPerTx, 2 = _minPerTx ]
+        uint256[] _homeDailyLimitHomeMaxPerTxArray, // [ 0 = _homeDailyLimit, 1 = _homeMaxPerTx ]
         address _owner,
         uint256 _decimalShift
     ) external returns (bool) {
@@ -18,7 +19,8 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc, ERC20Bridge {
             _erc20token,
             _requiredBlockConfirmations,
             _gasPrice,
-            _maxPerTxHomeDailyLimitHomeMaxPerTxArray,
+            _dailyLimitMaxPerTxMinPerTxArray,
+            _homeDailyLimitHomeMaxPerTxArray,
             _owner,
             _decimalShift
         );

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -141,7 +141,7 @@ contract HomeBridgeErcToErc is
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("erc-to-erc-core")));
+        return 0xba4690f5; // bytes4(keccak256(abi.encodePacked("erc-to-erc-core")))
     }
 
     function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns (bool) {

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNative.sol
@@ -7,7 +7,7 @@ import "../BlockRewardBridge.sol";
 
 contract FeeManagerErcToNative is ValidatorsFeeManager, BlockRewardBridge {
     function getFeeManagerMode() external pure returns (bytes4) {
-        return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
+        return 0xd7de965f; // bytes4(keccak256(abi.encodePacked("manages-both-directions")))
     }
 
     function onAffirmationFeeDistribution(address _rewardAddress, uint256 _fee) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
@@ -5,7 +5,7 @@ import "../BlockRewardFeeManager.sol";
 
 contract FeeManagerErcToNativePOSDAO is BlockRewardFeeManager {
     function getFeeManagerMode() external pure returns (bytes4) {
-        return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
+        return 0xd7de965f; // bytes4(keccak256(abi.encodePacked("manages-both-directions")))
     }
 
     function distributeFeeFromBlockReward(uint256 _fee) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -5,9 +5,6 @@ import "../ERC20Bridge.sol";
 import "../OtherSideBridgeStorage.sol";
 
 contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideBridgeStorage {
-    event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
-    event UserRequestForAffirmation(address recipient, uint256 value);
-
     function initialize(
         address _validatorContract,
         address _erc20token,
@@ -79,23 +76,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
     }
 
     function _relayTokens(address _sender, address _receiver, uint256 _amount) internal {
-        require(_receiver != address(0));
-        require(_receiver != address(this));
         require(_receiver != bridgeContractOnOtherSide());
-        require(_amount > 0);
-        require(withinLimit(_amount));
-        setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_amount));
-
-        erc20token().transferFrom(_sender, address(this), _amount);
-        emit UserRequestForAffirmation(_receiver, _amount);
-    }
-
-    function relayTokens(address _from, address _receiver, uint256 _amount) external {
-        require(_from == msg.sender || _from == _receiver);
-        _relayTokens(_from, _receiver, _amount);
-    }
-
-    function relayTokens(address _receiver, uint256 _amount) external {
-        _relayTokens(msg.sender, _receiver, _amount);
+        super._relayTokens(_sender, _receiver, _amount);
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -42,7 +42,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
+        return 0x18762d46; // bytes4(keccak256(abi.encodePacked("erc-to-native-core")))
     }
 
     function claimTokens(address _token, address _to) public {

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -5,38 +5,53 @@ import "../ERC20Bridge.sol";
 
 contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
     event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
+    event UserRequestForAffirmation(address recipient, uint256 value);
+
+    bytes32 internal constant BRIDGE_CONTRACT = 0x71483949fe7a14d16644d63320f24d10cf1d60abecc30cc677a340e82b699dd2; // keccak256(abi.encodePacked("bridgeOnOtherSide"))
 
     function initialize(
         address _validatorContract,
         address _erc20token,
         uint256 _requiredBlockConfirmations,
         uint256 _gasPrice,
-        uint256[] _maxPerTxHomeDailyLimitHomeMaxPerTxArray, //[ 0 = _maxPerTx, 1 = _homeDailyLimit, 2 = _homeMaxPerTx ]
+        uint256[] _dailyLimitMaxPerTxMinPerTxArray, // [ 0 = _dailyLimit, 1 = _maxPerTx, 2 = _minPerTx ]
+        uint256[] _homeDailyLimitHomeMaxPerTxArray, //[ 0 = _homeDailyLimit, 1 = _homeMaxPerTx ]
         address _owner,
-        uint256 _decimalShift
+        uint256 _decimalShift,
+        address _bridgeOnOtherSide
     ) external returns (bool) {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
         require(_requiredBlockConfirmations != 0);
         require(_gasPrice > 0);
-        require(_maxPerTxHomeDailyLimitHomeMaxPerTxArray[2] < _maxPerTxHomeDailyLimitHomeMaxPerTxArray[1]); // _homeMaxPerTx < _homeDailyLimit
+        require(
+            _dailyLimitMaxPerTxMinPerTxArray[2] > 0 && // _minPerTx > 0
+                _dailyLimitMaxPerTxMinPerTxArray[1] > _dailyLimitMaxPerTxMinPerTxArray[2] && // _maxPerTx > _minPerTx
+                _dailyLimitMaxPerTxMinPerTxArray[0] > _dailyLimitMaxPerTxMinPerTxArray[1] // _dailyLimit > _maxPerTx
+        );
+        require(_homeDailyLimitHomeMaxPerTxArray[1] < _homeDailyLimitHomeMaxPerTxArray[0]); // _homeMaxPerTx < _homeDailyLimit
         require(_owner != address(0));
+        require(_bridgeOnOtherSide != address(0));
 
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc20token(_erc20token);
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _requiredBlockConfirmations;
         uintStorage[GAS_PRICE] = _gasPrice;
-        uintStorage[MAX_PER_TX] = _maxPerTxHomeDailyLimitHomeMaxPerTxArray[0];
-        uintStorage[EXECUTION_DAILY_LIMIT] = _maxPerTxHomeDailyLimitHomeMaxPerTxArray[1];
-        uintStorage[EXECUTION_MAX_PER_TX] = _maxPerTxHomeDailyLimitHomeMaxPerTxArray[2];
+        uintStorage[DAILY_LIMIT] = _dailyLimitMaxPerTxMinPerTxArray[0];
+        uintStorage[MAX_PER_TX] = _dailyLimitMaxPerTxMinPerTxArray[1];
+        uintStorage[MIN_PER_TX] = _dailyLimitMaxPerTxMinPerTxArray[2];
+        uintStorage[EXECUTION_DAILY_LIMIT] = _homeDailyLimitHomeMaxPerTxArray[0];
+        uintStorage[EXECUTION_MAX_PER_TX] = _homeDailyLimitHomeMaxPerTxArray[1];
         uintStorage[DECIMAL_SHIFT] = _decimalShift;
         setOwner(_owner);
+        _setBridgeContractOnOtherSide(_bridgeOnOtherSide);
         setInitialize();
 
         emit RequiredBlockConfirmationChanged(_requiredBlockConfirmations);
         emit GasPriceChanged(_gasPrice);
-        emit ExecutionDailyLimitChanged(_maxPerTxHomeDailyLimitHomeMaxPerTxArray[1]);
+        emit DailyLimitChanged(_dailyLimitMaxPerTxMinPerTxArray[0]);
+        emit ExecutionDailyLimitChanged(_homeDailyLimitHomeMaxPerTxArray[0]);
 
         return isInitialized();
     }
@@ -62,5 +77,34 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
 
     function onFailedMessage(address, uint256, bytes32) internal {
         revert();
+    }
+
+    function _setBridgeContractOnOtherSide(address _bridgeContract) internal {
+        addressStorage[BRIDGE_CONTRACT] = _bridgeContract;
+    }
+
+    function bridgeContractOnOtherSide() public view returns (address) {
+        return addressStorage[BRIDGE_CONTRACT];
+    }
+
+    function _relayTokens(address _sender, address _receiver, uint256 _amount) internal {
+        require(_receiver != address(0));
+        require(_receiver != address(this));
+        require(_receiver != bridgeContractOnOtherSide());
+        require(_amount > 0);
+        require(withinLimit(_amount));
+        setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(_amount));
+
+        erc20token().transferFrom(_sender, address(this), _amount);
+        emit UserRequestForAffirmation(_receiver, _amount);
+    }
+
+    function relayTokens(address _from, address _receiver, uint256 _amount) external {
+        require(_from == msg.sender || _from == _receiver);
+        _relayTokens(_from, _receiver, _amount);
+    }
+
+    function relayTokens(address _receiver, uint256 _amount) external {
+        _relayTokens(msg.sender, _receiver, _amount);
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -2,12 +2,11 @@ pragma solidity 0.4.24;
 
 import "../BasicForeignBridge.sol";
 import "../ERC20Bridge.sol";
+import "../OtherSideBridgeStorage.sol";
 
-contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
+contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideBridgeStorage {
     event RelayedMessage(address recipient, uint256 value, bytes32 transactionHash);
     event UserRequestForAffirmation(address recipient, uint256 value);
-
-    bytes32 internal constant BRIDGE_CONTRACT = 0x71483949fe7a14d16644d63320f24d10cf1d60abecc30cc677a340e82b699dd2; // keccak256(abi.encodePacked("bridgeOnOtherSide"))
 
     function initialize(
         address _validatorContract,
@@ -77,14 +76,6 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
 
     function onFailedMessage(address, uint256, bytes32) internal {
         revert();
-    }
-
-    function _setBridgeContractOnOtherSide(address _bridgeContract) internal {
-        addressStorage[BRIDGE_CONTRACT] = _bridgeContract;
-    }
-
-    function bridgeContractOnOtherSide() public view returns (address) {
-        return addressStorage[BRIDGE_CONTRACT];
     }
 
     function _relayTokens(address _sender, address _receiver, uint256 _amount) internal {

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -4,7 +4,6 @@ import "../../libraries/Message.sol";
 import "../../upgradeability/EternalStorage.sol";
 import "../../interfaces/IBlockReward.sol";
 import "../BasicHomeBridge.sol";
-import "../ERC677Bridge.sol";
 import "../OverdrawManagement.sol";
 import "./RewardableHomeBridgeErcToNative.sol";
 import "../BlockRewardBridge.sol";

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -19,12 +19,12 @@ contract HomeBridgeErcToNative is
     bytes32 internal constant TOTAL_BURNT_COINS = 0x17f187b2e5d1f8770602b32c1159b85c9600859277fae1eaa9982e9bcf63384c; // keccak256(abi.encodePacked("totalBurntCoins"))
 
     function() public payable {
-        nativeTransfer();
+        require(msg.data.length == 0);
+        nativeTransfer(msg.sender);
     }
 
-    function nativeTransfer() internal {
+    function nativeTransfer(address _receiver) internal {
         require(msg.value > 0);
-        require(msg.data.length == 0);
         require(withinLimit(msg.value));
         IBlockReward blockReward = blockRewardContract();
         uint256 totalMinted = blockReward.mintedTotallyByBridge(address(this));
@@ -41,7 +41,11 @@ contract HomeBridgeErcToNative is
         }
         setTotalBurntCoins(totalBurnt.add(valueToBurn));
         address(0).transfer(valueToBurn);
-        emit UserRequestForSignature(msg.sender, valueToTransfer);
+        emit UserRequestForSignature(_receiver, valueToTransfer);
+    }
+
+    function relayTokens(address _receiver) external payable {
+        nativeTransfer(_receiver);
     }
 
     function initialize(

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -16,7 +16,7 @@ contract HomeBridgeErcToNative is
     RewardableHomeBridgeErcToNative,
     BlockRewardBridge
 {
-    bytes32 internal constant TOTAL_BURNT_COINS = keccak256(abi.encodePacked("totalBurntCoins"));
+    bytes32 internal constant TOTAL_BURNT_COINS = 0x17f187b2e5d1f8770602b32c1159b85c9600859277fae1eaa9982e9bcf63384c; // keccak256(abi.encodePacked("totalBurntCoins"))
 
     function() public payable {
         nativeTransfer();
@@ -101,7 +101,7 @@ contract HomeBridgeErcToNative is
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("erc-to-native-core")));
+        return 0x18762d46; // bytes4(keccak256(abi.encodePacked("erc-to-native-core")))
     }
 
     function blockRewardContract() public view returns (IBlockReward) {

--- a/contracts/upgradeable_contracts/native_to_erc20/ClassicHomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ClassicHomeBridgeNativeToErc.sol
@@ -21,7 +21,7 @@ contract ClassicHomeBridgeNativeToErc is HomeBridgeNativeToErc {
             _owner,
             _decimalShift
         );
-        uintStorage[keccak256(abi.encodePacked("dataSizes", bytes4(keccak256("signature(bytes32,uint256)"))))] = 132;
-        uintStorage[keccak256(abi.encodePacked("dataSizes", bytes4(keccak256("message(bytes32)"))))] = 210;
+        uintStorage[0x5e16d82565fc7ee8775cc18db290ff4010745d3fd46274a7bc7ddbebb727fa54] = 132; // keccak256(abi.encodePacked("dataSizes", bytes4(keccak256("signature(bytes32,uint256)"))))
+        uintStorage[0x3b0a1ac531be1657049cf649eca2510ce9e3ef7df1be26d5c248fe8b298f4374] = 210; // keccak256(abi.encodePacked("dataSizes", bytes4(keccak256("message(bytes32)"))))
     }
 }

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErc.sol
@@ -7,7 +7,7 @@ import "../ERC677Storage.sol";
 
 contract FeeManagerNativeToErc is ValidatorsFeeManager, ERC677Storage {
     function getFeeManagerMode() external pure returns (bytes4) {
-        return bytes4(keccak256(abi.encodePacked("manages-one-direction")));
+        return 0xf2aed8f7; // bytes4(keccak256(abi.encodePacked("manages-one-direction")))
     }
 
     function erc677token() public view returns (IBurnableMintableERC677Token) {

--- a/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErcBothDirections.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/FeeManagerNativeToErcBothDirections.sol
@@ -5,7 +5,7 @@ import "../ValidatorsFeeManager.sol";
 
 contract FeeManagerNativeToErcBothDirections is ValidatorsFeeManager {
     function getFeeManagerMode() external pure returns (bytes4) {
-        return bytes4(keccak256(abi.encodePacked("manages-both-directions")));
+        return 0xd7de965f; // bytes4(keccak256(abi.encodePacked("manages-both-directions")))
     }
 
     function onAffirmationFeeDistribution(address _rewardAddress, uint256 _fee) internal {

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 import "../BasicForeignBridge.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "../ERC677BridgeForBurnableMintableToken.sol";
 import "./RewardableForeignBridgeNativeToErc.sol";
 
@@ -11,9 +11,6 @@ contract ForeignBridgeNativeToErc is
     ERC677BridgeForBurnableMintableToken,
     RewardableForeignBridgeNativeToErc
 {
-    /// Event created on money withdraw.
-    event UserRequestForAffirmation(address recipient, uint256 value);
-
     function initialize(
         address _validatorContract,
         address _erc677token,

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -68,7 +68,7 @@ contract ForeignBridgeNativeToErc is
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
+        return 0x92a8d7fe; // bytes4(keccak256(abi.encodePacked("native-to-erc-core")))
     }
 
     function claimTokensFromErc677(address _token, address _to) external onlyIfUpgradeabilityOwner {

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -22,7 +22,8 @@ contract ForeignBridgeNativeToErc is
         uint256 _requiredBlockConfirmations,
         uint256[] _homeDailyLimitHomeMaxPerTxArray, // [ 0 = _homeDailyLimit, 1 = _homeMaxPerTx ]
         address _owner,
-        uint256 _decimalShift
+        uint256 _decimalShift,
+        address _bridgeOnOtherSide
     ) external returns (bool) {
         _initialize(
             _validatorContract,
@@ -32,7 +33,8 @@ contract ForeignBridgeNativeToErc is
             _requiredBlockConfirmations,
             _homeDailyLimitHomeMaxPerTxArray,
             _owner,
-            _decimalShift
+            _decimalShift,
+            _bridgeOnOtherSide
         );
         setInitialize();
         return isInitialized();
@@ -48,7 +50,8 @@ contract ForeignBridgeNativeToErc is
         address _owner,
         address _feeManager,
         uint256 _homeFee,
-        uint256 _decimalShift
+        uint256 _decimalShift,
+        address _bridgeOnOtherSide
     ) external returns (bool) {
         _initialize(
             _validatorContract,
@@ -58,7 +61,8 @@ contract ForeignBridgeNativeToErc is
             _requiredBlockConfirmations,
             _homeDailyLimitHomeMaxPerTxArray,
             _owner,
-            _decimalShift
+            _decimalShift,
+            _bridgeOnOtherSide
         );
         require(AddressUtils.isContract(_feeManager));
         addressStorage[FEE_MANAGER_CONTRACT] = _feeManager;
@@ -83,7 +87,8 @@ contract ForeignBridgeNativeToErc is
         uint256 _requiredBlockConfirmations,
         uint256[] _homeDailyLimitHomeMaxPerTxArray, // [ 0 = _homeDailyLimit, 1 = _homeMaxPerTx ]
         address _owner,
-        uint256 _decimalShift
+        uint256 _decimalShift,
+        address _bridgeOnOtherSide
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
@@ -109,6 +114,7 @@ contract ForeignBridgeNativeToErc is
         uintStorage[EXECUTION_MAX_PER_TX] = _homeDailyLimitHomeMaxPerTxArray[1];
         uintStorage[DECIMAL_SHIFT] = _decimalShift;
         setOwner(_owner);
+        _setBridgeContractOnOtherSide(_bridgeOnOtherSide);
 
         emit RequiredBlockConfirmationChanged(_requiredBlockConfirmations);
         emit GasPriceChanged(_foreignGasPrice);

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -8,12 +8,12 @@ import "../Sacrifice.sol";
 
 contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHomeBridgeNativeToErc {
     function() public payable {
-        nativeTransfer();
+        require(msg.data.length == 0);
+        nativeTransfer(msg.sender);
     }
 
-    function nativeTransfer() internal {
+    function nativeTransfer(address _receiver) internal {
         require(msg.value > 0);
-        require(msg.data.length == 0);
         require(withinLimit(msg.value));
         setTotalSpentPerDay(getCurrentDay(), totalSpentPerDay(getCurrentDay()).add(msg.value));
         uint256 valueToTransfer = msg.value;
@@ -22,7 +22,11 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
             uint256 fee = calculateFee(valueToTransfer, false, feeManager, HOME_FEE);
             valueToTransfer = valueToTransfer.sub(fee);
         }
-        emit UserRequestForSignature(msg.sender, valueToTransfer);
+        emit UserRequestForSignature(_receiver, valueToTransfer);
+    }
+
+    function relayTokens(address _receiver) external payable {
+        nativeTransfer(_receiver);
     }
 
     function initialize(

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -76,7 +76,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {
-        return bytes4(keccak256(abi.encodePacked("native-to-erc-core")));
+        return 0x92a8d7fe; // bytes4(keccak256(abi.encodePacked("native-to-erc-core")))
     }
 
     function _initialize(

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -73,7 +73,7 @@ async function deployErcToNative() {
   const deployForeign = require('./src/erc_to_native/foreign')
   await preDeploy()
   const { homeBridge } = await deployHome()
-  const { foreignBridge } = await deployForeign()
+  const { foreignBridge } = await deployForeign(homeBridge.address)
   console.log('\nDeployment has been completed.\n\n')
   console.log(`[ Home ] HomeBridge: ${homeBridge.address} at block ${homeBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] ForeignBridge: ${foreignBridge.address} at block ${foreignBridge.deployedBlockNumber}`)

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -12,7 +12,7 @@ async function deployNativeToErc() {
   const deployForeign = require('./src/native_to_erc/foreign')
   await preDeploy()
   const { homeBridge } = await deployHome()
-  const { foreignBridge, erc677 } = await deployForeign()
+  const { foreignBridge, erc677 } = await deployForeign(homeBridge.address)
   console.log('\nDeployment has been completed.\n\n')
   console.log(`[   Home  ] HomeBridge: ${homeBridge.address} at block ${homeBridge.deployedBlockNumber}`)
   console.log(`[ Foreign ] ForeignBridge: ${foreignBridge.address} at block ${foreignBridge.deployedBlockNumber}`)

--- a/deploy/src/erc_to_erc/foreign.js
+++ b/deploy/src/erc_to_erc/foreign.js
@@ -57,34 +57,20 @@ async function initializeBridge({ validatorsBridge, bridge, nonce }) {
   FOREIGN_BRIDGE_OWNER: ${FOREIGN_BRIDGE_OWNER},
   FOREIGN_TO_HOME_DECIMAL_SHIFT: ${foreignToHomeDecimalShift}
   `)
-  let initializeFBridgeData
 
-  if (ERC20_EXTENDED_BY_ERC677) {
-    initializeFBridgeData = await bridge.methods
-      .initialize(
-        validatorsBridge.options.address,
-        ERC20_TOKEN_ADDRESS,
-        FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS,
-        FOREIGN_GAS_PRICE,
-        [FOREIGN_DAILY_LIMIT, FOREIGN_MAX_AMOUNT_PER_TX, FOREIGN_MIN_AMOUNT_PER_TX],
-        [HOME_DAILY_LIMIT, HOME_MAX_AMOUNT_PER_TX],
-        FOREIGN_BRIDGE_OWNER,
-        foreignToHomeDecimalShift
-      )
-      .encodeABI()
-  } else {
-    initializeFBridgeData = await bridge.methods
-      .initialize(
-        validatorsBridge.options.address,
-        ERC20_TOKEN_ADDRESS,
-        FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS,
-        FOREIGN_GAS_PRICE,
-        [FOREIGN_MAX_AMOUNT_PER_TX, HOME_DAILY_LIMIT, HOME_MAX_AMOUNT_PER_TX],
-        FOREIGN_BRIDGE_OWNER,
-        foreignToHomeDecimalShift
-      )
-      .encodeABI()
-  }
+  const initializeFBridgeData = await bridge.methods
+    .initialize(
+      validatorsBridge.options.address,
+      ERC20_TOKEN_ADDRESS,
+      FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS,
+      FOREIGN_GAS_PRICE,
+      [FOREIGN_DAILY_LIMIT, FOREIGN_MAX_AMOUNT_PER_TX, FOREIGN_MIN_AMOUNT_PER_TX],
+      [HOME_DAILY_LIMIT, HOME_MAX_AMOUNT_PER_TX],
+      FOREIGN_BRIDGE_OWNER,
+      foreignToHomeDecimalShift
+    )
+    .encodeABI()
+
   const txInitializeBridge = await sendRawTxForeign({
     data: initializeFBridgeData,
     nonce,

--- a/deploy/src/erc_to_native/foreign.js
+++ b/deploy/src/erc_to_native/foreign.js
@@ -27,7 +27,9 @@ const {
   FOREIGN_UPGRADEABLE_ADMIN,
   FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS,
   ERC20_TOKEN_ADDRESS,
+  FOREIGN_DAILY_LIMIT,
   FOREIGN_MAX_AMOUNT_PER_TX,
+  FOREIGN_MIN_AMOUNT_PER_TX,
   HOME_DAILY_LIMIT,
   HOME_MAX_AMOUNT_PER_TX,
   FOREIGN_TO_HOME_DECIMAL_SHIFT
@@ -37,17 +39,22 @@ const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVAT
 
 const foreignToHomeDecimalShift = FOREIGN_TO_HOME_DECIMAL_SHIFT || 0
 
-async function initializeBridge({ validatorsBridge, bridge, nonce }) {
+async function initializeBridge({ validatorsBridge, bridge, nonce, homeBridgeAddress }) {
   console.log(`Foreign Validators: ${validatorsBridge.options.address},
   ERC20_TOKEN_ADDRESS: ${ERC20_TOKEN_ADDRESS},
+  FOREIGN_DAILY_LIMIT: ${FOREIGN_DAILY_LIMIT} which is ${Web3Utils.fromWei(FOREIGN_DAILY_LIMIT)} in eth,
   FOREIGN_MAX_AMOUNT_PER_TX: ${FOREIGN_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
     FOREIGN_MAX_AMOUNT_PER_TX
   )} in eth,
+  FOREIGN_MIN_AMOUNT_PER_TX: ${FOREIGN_MIN_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
+    FOREIGN_MIN_AMOUNT_PER_TX
+  )} in eth,
   FOREIGN_GAS_PRICE: ${FOREIGN_GAS_PRICE}, FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS : ${FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS},
-    HOME_DAILY_LIMIT: ${HOME_DAILY_LIMIT} which is ${Web3Utils.fromWei(HOME_DAILY_LIMIT)} in eth,
+  HOME_DAILY_LIMIT: ${HOME_DAILY_LIMIT} which is ${Web3Utils.fromWei(HOME_DAILY_LIMIT)} in eth,
   HOME_MAX_AMOUNT_PER_TX: ${HOME_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(HOME_MAX_AMOUNT_PER_TX)} in eth,
   FOREIGN_BRIDGE_OWNER: ${FOREIGN_BRIDGE_OWNER},
-  FOREIGN_TO_HOME_DECIMAL_SHIFT: ${foreignToHomeDecimalShift}
+  FOREIGN_TO_HOME_DECIMAL_SHIFT: ${foreignToHomeDecimalShift},
+  Home bridge Address: ${homeBridgeAddress}
   `)
   const initializeFBridgeData = await bridge.methods
     .initialize(
@@ -55,9 +62,11 @@ async function initializeBridge({ validatorsBridge, bridge, nonce }) {
       ERC20_TOKEN_ADDRESS,
       FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS,
       FOREIGN_GAS_PRICE,
-      [FOREIGN_MAX_AMOUNT_PER_TX, HOME_DAILY_LIMIT, HOME_MAX_AMOUNT_PER_TX],
+      [FOREIGN_DAILY_LIMIT, FOREIGN_MAX_AMOUNT_PER_TX, FOREIGN_MIN_AMOUNT_PER_TX],
+      [HOME_DAILY_LIMIT, HOME_MAX_AMOUNT_PER_TX],
       FOREIGN_BRIDGE_OWNER,
-      foreignToHomeDecimalShift
+      foreignToHomeDecimalShift,
+      homeBridgeAddress
     )
     .encodeABI()
   const txInitializeBridge = await sendRawTxForeign({
@@ -74,7 +83,7 @@ async function initializeBridge({ validatorsBridge, bridge, nonce }) {
   }
 }
 
-async function deployForeign() {
+async function deployForeign(homeBridgeAddress) {
   if (!Web3Utils.isAddress(ERC20_TOKEN_ADDRESS)) {
     throw new Error('ERC20_TOKEN_ADDRESS env var is not defined')
   }
@@ -167,7 +176,8 @@ async function deployForeign() {
   await initializeBridge({
     validatorsBridge: storageValidatorsForeign,
     bridge: foreignBridgeImplementation,
-    nonce
+    nonce,
+    homeBridgeAddress
   })
   nonce++
 

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -75,7 +75,6 @@ const {
   VALIDATORS_REWARD_ACCOUNTS,
   DEPLOY_REWARDABLE_TOKEN,
   HOME_FEE_MANAGER_TYPE,
-  ERC20_EXTENDED_BY_ERC677,
   HOME_EVM_VERSION,
   FOREIGN_EVM_VERSION
 } = process.env
@@ -223,14 +222,8 @@ if (BRIDGE_MODE === 'ERC_TO_ERC') {
     BRIDGEABLE_TOKEN_SYMBOL: envalid.str(),
     BRIDGEABLE_TOKEN_DECIMALS: envalid.num(),
     DEPLOY_REWARDABLE_TOKEN: envalid.bool(),
-    ERC20_EXTENDED_BY_ERC677: envalid.bool()
-  }
-
-  if (ERC20_EXTENDED_BY_ERC677 === 'true') {
-    validations = {
-      ...validations,
-      FOREIGN_MIN_AMOUNT_PER_TX: bigNumValidator()
-    }
+    ERC20_EXTENDED_BY_ERC677: envalid.bool(),
+    FOREIGN_MIN_AMOUNT_PER_TX: bigNumValidator()
   }
 
   if (DEPLOY_REWARDABLE_TOKEN === 'true') {
@@ -289,11 +282,7 @@ if (env.BRIDGE_MODE === 'NATIVE_TO_ERC') {
 }
 
 if (env.BRIDGE_MODE === 'ERC_TO_ERC') {
-  if (env.ERC20_EXTENDED_BY_ERC677) {
-    checkLimits(env.FOREIGN_MIN_AMOUNT_PER_TX, env.FOREIGN_MAX_AMOUNT_PER_TX, env.FOREIGN_DAILY_LIMIT, foreignPrefix)
-  } else if (env.FOREIGN_MAX_AMOUNT_PER_TX.gte(env.FOREIGN_DAILY_LIMIT)) {
-    throw new Error(`FOREIGN_DAILY_LIMIT should be greater than FOREIGN_MAX_AMOUNT_PER_TX`)
-  }
+  checkLimits(env.FOREIGN_MIN_AMOUNT_PER_TX, env.FOREIGN_MAX_AMOUNT_PER_TX, env.FOREIGN_DAILY_LIMIT, foreignPrefix)
 
   if (env.HOME_REWARDABLE === 'BOTH_DIRECTIONS' && env.BLOCK_REWARD_ADDRESS === ZERO_ADDRESS) {
     throw new Error(

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -248,7 +248,8 @@ if (BRIDGE_MODE === 'ERC_TO_NATIVE') {
     ERC20_TOKEN_ADDRESS: addressValidator(),
     BLOCK_REWARD_ADDRESS: addressValidator({
       default: ZERO_ADDRESS
-    })
+    }),
+    FOREIGN_MIN_AMOUNT_PER_TX: bigNumValidator()
   }
 }
 
@@ -282,9 +283,7 @@ if (env.BRIDGE_MODE === 'NATIVE_TO_ERC') {
 
   if (env.HOME_REWARDABLE === 'BOTH_DIRECTIONS' && env.FOREIGN_REWARDABLE === 'ONE_DIRECTION') {
     throw new Error(
-      `Combination of HOME_REWARDABLE: ${env.HOME_REWARDABLE} and FOREIGN_REWARDABLE: ${
-        env.FOREIGN_REWARDABLE
-      } should be avoided on ${env.BRIDGE_MODE} bridge mode.`
+      `Combination of HOME_REWARDABLE: ${env.HOME_REWARDABLE} and FOREIGN_REWARDABLE: ${env.FOREIGN_REWARDABLE} should be avoided on ${env.BRIDGE_MODE} bridge mode.`
     )
   }
 }
@@ -308,9 +307,7 @@ if (env.BRIDGE_MODE === 'ERC_TO_ERC') {
 }
 
 if (env.BRIDGE_MODE === 'ERC_TO_NATIVE') {
-  if (env.FOREIGN_MAX_AMOUNT_PER_TX.gte(env.FOREIGN_DAILY_LIMIT)) {
-    throw new Error(`FOREIGN_DAILY_LIMIT should be greater than FOREIGN_MAX_AMOUNT_PER_TX`)
-  }
+  checkLimits(env.FOREIGN_MIN_AMOUNT_PER_TX, env.FOREIGN_MAX_AMOUNT_PER_TX, env.FOREIGN_DAILY_LIMIT, foreignPrefix)
 
   if (HOME_REWARDABLE === 'ONE_DIRECTION') {
     throw new Error(

--- a/deploy/src/native_to_erc/foreign.js
+++ b/deploy/src/native_to_erc/foreign.js
@@ -64,7 +64,7 @@ if (isRewardableBridge) {
   VALIDATORS_REWARD_ACCOUNTS = env.VALIDATORS_REWARD_ACCOUNTS.split(' ')
 }
 
-async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, initialNonce }) {
+async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, initialNonce, homeBridgeAddress }) {
   let nonce = initialNonce
   let initializeFBridgeData
 
@@ -95,7 +95,8 @@ async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, i
   FOREIGN_BRIDGE_OWNER: ${FOREIGN_BRIDGE_OWNER},
   Fee Manager: ${feeManager.options.address},
   Home Fee: ${homeFeeInWei} which is ${HOME_TRANSACTIONS_FEE * 100}%,
-  FOREIGN_TO_HOME_DECIMAL_SHIFT: ${foreignToHomeDecimalShift}`)
+  FOREIGN_TO_HOME_DECIMAL_SHIFT: ${foreignToHomeDecimalShift}
+  Home bridge Address: ${homeBridgeAddress}`)
 
     initializeFBridgeData = await bridge.methods
       .rewardableInitialize(
@@ -108,7 +109,8 @@ async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, i
         FOREIGN_BRIDGE_OWNER,
         feeManager.options.address,
         homeFeeInWei,
-        foreignToHomeDecimalShift
+        foreignToHomeDecimalShift,
+        homeBridgeAddress
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
   } else {
@@ -126,6 +128,7 @@ async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, i
   HOME_MAX_AMOUNT_PER_TX: ${HOME_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(HOME_MAX_AMOUNT_PER_TX)} in eth,
   FOREIGN_BRIDGE_OWNER: ${FOREIGN_BRIDGE_OWNER},
   FOREIGN_TO_HOME_DECIMAL_SHIFT: ${foreignToHomeDecimalShift}
+  Home bridge Address: ${homeBridgeAddress}
   `)
 
     initializeFBridgeData = await bridge.methods
@@ -137,7 +140,8 @@ async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, i
         FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS,
         [HOME_DAILY_LIMIT, HOME_MAX_AMOUNT_PER_TX],
         FOREIGN_BRIDGE_OWNER,
-        foreignToHomeDecimalShift
+        foreignToHomeDecimalShift,
+        homeBridgeAddress
       )
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
   }
@@ -159,7 +163,7 @@ async function initializeBridge({ validatorsBridge, bridge, erc677bridgeToken, i
   return nonce
 }
 
-async function deployForeign() {
+async function deployForeign(homeBridgeAddress) {
   let nonce = await web3Foreign.eth.getTransactionCount(DEPLOYMENT_ACCOUNT_ADDRESS)
   console.log('========================================')
   console.log('deploying ForeignBridge')
@@ -259,7 +263,8 @@ async function deployForeign() {
     validatorsBridge: storageValidatorsForeign,
     bridge: foreignBridgeImplementation,
     erc677bridgeToken,
-    initialNonce: nonce
+    initialNonce: nonce,
+    homeBridgeAddress
   })
 
   console.log('\nset bridge contract on ERC677BridgeToken')

--- a/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
+++ b/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
@@ -45,7 +45,6 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       expect(await contract.executionMaxPerTx()).to.be.bignumber.equal(ZERO)
       expect(await contract.requestGasLimit()).to.be.bignumber.equal(ZERO)
       expect(await contract.owner()).to.be.equal(ZERO_ADDRESS)
-      expect(await contract.deployedAtBlock()).to.be.bignumber.equal(ZERO)
 
       // not valid bridge contract
       await contract
@@ -167,7 +166,6 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       expect(await contract.executionMaxPerTx()).to.be.bignumber.equal(executionMaxPerTx)
       expect(await contract.requestGasLimit()).to.be.bignumber.equal(maxGasPerTx)
       expect(await contract.owner()).to.be.equal(owner)
-      expect(await contract.deployedAtBlock()).to.be.bignumber.above(ZERO)
 
       expectEventInLogs(logs, 'ExecutionDailyLimitChanged', { newLimit: executionDailyLimit })
       expectEventInLogs(logs, 'DailyLimitChanged', { newLimit: dailyLimit })

--- a/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
+++ b/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
@@ -521,6 +521,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -531,6 +534,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow user to specify a itself as receiver', async () => {
       // Given
@@ -545,6 +549,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -557,6 +564,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow to specify a different receiver', async () => {
       // Given
@@ -571,6 +579,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -583,6 +594,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow to specify a different receiver without specifying sender', async () => {
       // Given
@@ -597,6 +609,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -608,6 +623,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should allow to complete a transfer approved by other user', async () => {
       // Given
@@ -621,6 +637,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         decimalShiftZero,
         owner
       ).should.be.fulfilled
+
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
 
       const value = oneEther
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
@@ -637,6 +656,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
       expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should fail if user did not approve the transfer', async () => {
       await contract.initialize(
@@ -690,6 +710,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc677Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc677Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -700,6 +723,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
     it('should prevent emitting the event twice when ERC677 used by relayTokens and ERC677 is not owned by token manager', async function() {
       // Given
@@ -719,6 +743,9 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
+      const currentDay = await contract.getCurrentDay()
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
       const value = oneEther
       await erc677Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc677Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
@@ -729,6 +756,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+      expect(await contract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
     })
   })
   describe('requestFailedMessageFix', () => {

--- a/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
+++ b/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
@@ -498,6 +498,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
   describe('relayTokens', () => {
     let contract
     let erc20Token
+    const user2 = accounts[2]
     beforeEach(async function() {
       bridgeContract = await AMBMock.new()
       await bridgeContract.setMaxGasPerTx(maxGasPerTx)
@@ -525,11 +526,117 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
 
       // When
-      await contract.relayTokens(value, { from: user }).should.be.fulfilled
+      await contract.relayTokens(user, value, { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
       expect(events.length).to.be.equal(1)
+    })
+    it('should allow user to specify a itself as receiver', async () => {
+      // Given
+      await contract.initialize(
+        bridgeContract.address,
+        mediatorContract.address,
+        erc20Token.address,
+        [dailyLimit, maxPerTx, minPerTx],
+        [executionDailyLimit, executionMaxPerTx],
+        maxGasPerTx,
+        decimalShiftZero,
+        owner
+      ).should.be.fulfilled
+
+      const value = oneEther
+      await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
+      expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
+
+      // When
+      await contract.methods['relayTokens(address,address,uint256)'](user, user, value, { from: user }).should.be
+        .fulfilled
+
+      // Then
+      const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
+      expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+    })
+    it('should allow to specify a different receiver', async () => {
+      // Given
+      await contract.initialize(
+        bridgeContract.address,
+        mediatorContract.address,
+        erc20Token.address,
+        [dailyLimit, maxPerTx, minPerTx],
+        [executionDailyLimit, executionMaxPerTx],
+        maxGasPerTx,
+        decimalShiftZero,
+        owner
+      ).should.be.fulfilled
+
+      const value = oneEther
+      await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
+      expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
+
+      // When
+      await contract.methods['relayTokens(address,address,uint256)'](user, user2, value, { from: user }).should.be
+        .fulfilled
+
+      // Then
+      const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
+      expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
+    })
+    it('should allow to specify a different receiver without specifying sender', async () => {
+      // Given
+      await contract.initialize(
+        bridgeContract.address,
+        mediatorContract.address,
+        erc20Token.address,
+        [dailyLimit, maxPerTx, minPerTx],
+        [executionDailyLimit, executionMaxPerTx],
+        maxGasPerTx,
+        decimalShiftZero,
+        owner
+      ).should.be.fulfilled
+
+      const value = oneEther
+      await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
+      expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
+
+      // When
+      await contract.relayTokens(user2, value, { from: user }).should.be.fulfilled
+
+      // Then
+      const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
+      expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
+    })
+    it('should allow to complete a transfer approved by other user', async () => {
+      // Given
+      await contract.initialize(
+        bridgeContract.address,
+        mediatorContract.address,
+        erc20Token.address,
+        [dailyLimit, maxPerTx, minPerTx],
+        [executionDailyLimit, executionMaxPerTx],
+        maxGasPerTx,
+        decimalShiftZero,
+        owner
+      ).should.be.fulfilled
+
+      const value = oneEther
+      await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
+      expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
+
+      // When
+      await contract.methods['relayTokens(address,address,uint256)'](user, user2, value, {
+        from: user2
+      }).should.be.rejectedWith(ERROR_MSG)
+      await contract.methods['relayTokens(address,address,uint256)'](user, user, value, { from: user2 }).should.be
+        .fulfilled
+
+      // Then
+      const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
+      expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
     })
     it('should fail if user did not approve the transfer', async () => {
       await contract.initialize(
@@ -543,7 +650,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.fulfilled
 
-      await contract.relayTokens(oneEther, { from: user }).should.be.rejectedWith(ERROR_MSG)
+      await contract.relayTokens(user, oneEther, { from: user }).should.be.rejectedWith(ERROR_MSG)
     })
     it('should fail if value is not within limits', async () => {
       await contract.initialize(
@@ -561,7 +668,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       await erc20Token.approve(contract.address, value, { from: user }).should.be.fulfilled
       expect(await erc20Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
 
-      await contract.relayTokens(value, { from: user }).should.be.rejectedWith(ERROR_MSG)
+      await contract.relayTokens(user, value, { from: user }).should.be.rejectedWith(ERROR_MSG)
     })
     it('should prevent emitting the event twice when ERC677 used by relayTokens and ERC677 is owned by token manager', async function() {
       // Given
@@ -588,7 +695,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       expect(await erc677Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
 
       // When
-      await contract.relayTokens(value, { from: user }).should.be.fulfilled
+      await contract.relayTokens(user, value, { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
@@ -617,7 +724,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       expect(await erc677Token.allowance(user, contract.address)).to.be.bignumber.equal(value)
 
       // When
-      await contract.relayTokens(value, { from: user }).should.be.fulfilled
+      await contract.relayTokens(user, value, { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(bridgeContract, { event: 'MockedEvent' })
@@ -761,7 +868,7 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
       expect(await erc677Token.totalSupply()).to.be.bignumber.equal(twoEthers)
 
       // User transfer tokens
-      const transferTx = await erc677Token.transferAndCall(contract.address, oneEther, '0x00', { from: user }).should.be
+      const transferTx = await erc677Token.transferAndCall(contract.address, oneEther, '0x', { from: user }).should.be
         .fulfilled
 
       expect(await erc677Token.balanceOf(user)).to.be.bignumber.equal(oneEther)

--- a/test/amb_erc677_to_erc677/foreign_bridge.test.js
+++ b/test/amb_erc677_to_erc677/foreign_bridge.test.js
@@ -9,7 +9,7 @@ const AMBMock = artifacts.require('AMBMock.sol')
 const { expect } = require('chai')
 const { shouldBehaveLikeBasicAMBErc677ToErc677 } = require('./AMBErc677ToErc677Behavior.test')
 const { ether } = require('../helpers/helpers')
-const { getEvents } = require('../helpers/helpers')
+const { getEvents, strip0x } = require('../helpers/helpers')
 const { ERROR_MSG, toBN } = require('../setup')
 
 const ZERO = toBN(0)
@@ -70,19 +70,48 @@ contract('ForeignAMBErc677ToErc677', async accounts => {
       expect(initialEvents.length).to.be.equal(0)
 
       // only token address can call it
-      await foreignBridge.onTokenTransfer(user, halfEther, '0x00', { from: owner }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.onTokenTransfer(user, halfEther, '0x', { from: owner }).should.be.rejectedWith(ERROR_MSG)
 
       // must be within limits
       await erc677Token
-        .transferAndCall(foreignBridge.address, twoEthers, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, twoEthers, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
 
       // When
-      await erc677Token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await erc677Token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(ambBridgeContract, { event: 'UserRequestForAffirmation' })
       expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(halfEther)
+    })
+    it('should be able to specify a different receiver', async () => {
+      // Given
+      const user2 = accounts[2]
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+      const initialEvents = await getEvents(ambBridgeContract, { event: 'UserRequestForAffirmation' })
+      expect(initialEvents.length).to.be.equal(0)
+
+      // only token address can call it
+      await foreignBridge.onTokenTransfer(user, halfEther, '0x', { from: owner }).should.be.rejectedWith(ERROR_MSG)
+
+      // must be within limits
+      await erc677Token
+        .transferAndCall(foreignBridge.address, twoEthers, '0x', { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+
+      // When
+      await erc677Token
+        .transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      await erc677Token.transferAndCall(foreignBridge.address, halfEther, user2, { from: user }).should.be.fulfilled
+
+      // Then
+      const events = await getEvents(ambBridgeContract, { event: 'UserRequestForAffirmation' })
+      expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
       expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(halfEther)
     })
   })

--- a/test/amb_erc677_to_erc677/home_bridge.test.js
+++ b/test/amb_erc677_to_erc677/home_bridge.test.js
@@ -10,7 +10,7 @@ const { expect } = require('chai')
 const { shouldBehaveLikeBasicAMBErc677ToErc677 } = require('./AMBErc677ToErc677Behavior.test')
 
 const { ether } = require('../helpers/helpers')
-const { getEvents, expectEventInLogs } = require('../helpers/helpers')
+const { getEvents, expectEventInLogs, strip0x } = require('../helpers/helpers')
 const { ERROR_MSG, toBN } = require('../setup')
 
 const ZERO = toBN(0)
@@ -71,20 +71,48 @@ contract('HomeAMBErc677ToErc677', async accounts => {
       expect(await erc677Token.totalSupply()).to.be.bignumber.equal(twoEthers)
 
       // only token address can call it
-      await homeBridge.onTokenTransfer(user, oneEther, '0x00', { from: owner }).should.be.rejectedWith(ERROR_MSG)
+      await homeBridge.onTokenTransfer(user, oneEther, '0x', { from: owner }).should.be.rejectedWith(ERROR_MSG)
 
       // must be within limits
       await erc677Token
-        .transferAndCall(homeBridge.address, twoEthers, '0x00', { from: user })
+        .transferAndCall(homeBridge.address, twoEthers, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
 
       // When
-      const { logs } = await erc677Token.transferAndCall(homeBridge.address, oneEther, '0x00', { from: user }).should.be
+      const { logs } = await erc677Token.transferAndCall(homeBridge.address, oneEther, '0x', { from: user }).should.be
         .fulfilled
 
       // Then
       const events = await getEvents(ambBridgeContract, { event: 'UserRequestForSignature' })
       expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user).toLowerCase())).to.be.equal(true)
+      expect(await homeBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(oneEther)
+      expect(await erc677Token.totalSupply()).to.be.bignumber.equal(oneEther)
+      expectEventInLogs(logs, 'Burn', {
+        burner: homeBridge.address,
+        value: oneEther
+      })
+    })
+    it('should be able to specify a different receiver', async () => {
+      const user2 = accounts[2]
+      // Given
+      const currentDay = await homeBridge.getCurrentDay()
+      expect(await homeBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+      const initialEvents = await getEvents(ambBridgeContract, { event: 'UserRequestForSignature' })
+      expect(initialEvents.length).to.be.equal(0)
+      expect(await erc677Token.totalSupply()).to.be.bignumber.equal(twoEthers)
+
+      // When
+      await erc677Token
+        .transferAndCall(homeBridge.address, oneEther, '0x00', { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      const { logs } = await erc677Token.transferAndCall(homeBridge.address, oneEther, user2, { from: user }).should.be
+        .fulfilled
+
+      // Then
+      const events = await getEvents(ambBridgeContract, { event: 'UserRequestForSignature' })
+      expect(events.length).to.be.equal(1)
+      expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
       expect(await homeBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(oneEther)
       expect(await erc677Token.totalSupply()).to.be.bignumber.equal(oneEther)
       expectEventInLogs(logs, 'Burn', {

--- a/test/erc_to_erc/foreign_bridge.test.js
+++ b/test/erc_to_erc/foreign_bridge.test.js
@@ -32,7 +32,6 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
     owner = accounts[0]
     await validatorContract.initialize(1, authorities, owner)
   })
-
   describe('#initialize', async () => {
     it('should initialize', async () => {
       token = await ERC677BridgeToken.new('Some ERC20', 'RSZT', 18)
@@ -51,7 +50,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           token.address,
           requireBlockConfirmations,
           gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
+          [dailyLimit, maxPerTx, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
           owner,
           decimalShiftZero
         )
@@ -62,7 +62,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           ZERO_ADDRESS,
           requireBlockConfirmations,
           gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
+          [dailyLimit, maxPerTx, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
           owner,
           decimalShiftZero
         )
@@ -73,7 +74,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           owner,
           requireBlockConfirmations,
           gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
+          [dailyLimit, maxPerTx, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
           owner,
           decimalShiftZero
         )
@@ -84,7 +86,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           token.address,
           0,
           gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
+          [dailyLimit, maxPerTx, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
           owner,
           decimalShiftZero
         )
@@ -95,7 +98,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           token.address,
           requireBlockConfirmations,
           0,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
+          [dailyLimit, maxPerTx, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
           owner,
           decimalShiftZero
         )
@@ -106,7 +110,33 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           token.address,
           requireBlockConfirmations,
           gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
+          [dailyLimit, maxPerTx, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
+          owner,
+          decimalShiftZero
+        )
+        .should.be.rejectedWith(ERROR_MSG)
+
+      await foreignBridge
+        .initialize(
+          validatorContract.address,
+          token.address,
+          requireBlockConfirmations,
+          gasPrice,
+          [dailyLimit, maxPerTx, maxPerTx],
+          [homeDailyLimit, homeMaxPerTx],
+          owner,
+          decimalShiftZero
+        )
+        .should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge
+        .initialize(
+          validatorContract.address,
+          token.address,
+          requireBlockConfirmations,
+          gasPrice,
+          [dailyLimit, dailyLimit, minPerTx],
+          [homeDailyLimit, homeMaxPerTx],
           owner,
           decimalShiftZero
         )
@@ -117,7 +147,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         '9'
       )
@@ -129,6 +160,9 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       expect(await foreignBridge.requiredBlockConfirmations()).to.be.bignumber.equal(
         requireBlockConfirmations.toString()
       )
+      expect(await foreignBridge.dailyLimit()).to.be.bignumber.equal(dailyLimit)
+      expect(await foreignBridge.maxPerTx()).to.be.bignumber.equal(maxPerTx)
+      expect(await foreignBridge.minPerTx()).to.be.bignumber.equal(minPerTx)
       expect(await foreignBridge.decimalShift()).to.be.bignumber.equal('9')
       expect(await foreignBridge.gasPrice()).to.be.bignumber.equal(gasPrice)
       const bridgeMode = '0xba4690f5' // 4 bytes of keccak256('erc-to-erc-core')
@@ -142,10 +176,10 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         requiredBlockConfirmations: toBN(requireBlockConfirmations)
       })
       expectEventInLogs(logs, 'GasPriceChanged', { gasPrice })
+      expectEventInLogs(logs, 'DailyLimitChanged', { newLimit: dailyLimit })
       expectEventInLogs(logs, 'ExecutionDailyLimitChanged', { newLimit: homeDailyLimit })
     })
   })
-
   describe('#executeSignatures', async () => {
     const value = ether('0.25')
     let foreignBridge
@@ -157,7 +191,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero
       )
@@ -288,7 +323,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero,
         { from: ownerOfValidatorContract }
@@ -348,7 +384,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         erc20Token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero
       )
@@ -408,7 +445,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero
       )
@@ -436,7 +474,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
           tokenAddress,
           requireBlockConfirmations,
           gasPrice,
-          ['2', '3', '2'],
+          ['3', '2', '1'],
+          ['3', '2'],
           owner,
           decimalShiftZero
         )
@@ -460,7 +499,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero
       )
@@ -523,9 +563,9 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
 
       await token.mint(user, halfEther, { from: owner }).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address, { from: owner })
-      await foreignBridge.onTokenTransfer(user, halfEther, '0x00', { from: owner }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.onTokenTransfer(user, halfEther, '0x', { from: owner }).should.be.rejectedWith(ERROR_MSG)
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
       expect(await token.totalSupply()).to.be.bignumber.equal(halfEther)
       expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)
       expect(await token.balanceOf(foreignBridge.address)).to.be.bignumber.equal(halfEther)
@@ -555,12 +595,12 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       await token.transferOwnership(foreignBridge.address, { from: owner })
 
       await token
-        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
       valueMoreThanLimit.should.be.bignumber.equal(await token.totalSupply())
       valueMoreThanLimit.should.be.bignumber.equal(await token.balanceOf(user))
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
 
       expect(await token.totalSupply()).to.be.bignumber.equal(valueMoreThanLimit)
       expect(await token.balanceOf(user)).to.be.bignumber.equal('1')
@@ -590,25 +630,25 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       await token.transferOwnership(foreignBridge.address, { from: owner })
 
       await token
-        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
       oneEther.add(toBN(1)).should.be.bignumber.equal(await token.totalSupply())
       oneEther.add(toBN(1)).should.be.bignumber.equal(await token.balanceOf(user))
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
       oneEther.add(toBN(1)).should.be.bignumber.equal(await token.totalSupply())
       valueMoreThanLimit.should.be.bignumber.equal(await token.balanceOf(user))
       const events = await getEvents(foreignBridge, { event: 'UserRequestForAffirmation' })
       expect(events[0].returnValues.recipient).to.be.equal(user)
       expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(halfEther)
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
 
       expect(await token.totalSupply()).to.be.bignumber.equal(oneEther.add(toBN(1)))
       expect(await token.balanceOf(user)).to.be.bignumber.equal('1')
       expect(await token.balanceOf(foreignBridge.address)).to.be.bignumber.equal(oneEther)
 
-      await token.transferAndCall(foreignBridge.address, '1', '0x00', { from: user }).should.be.rejectedWith(ERROR_MSG)
+      await token.transferAndCall(foreignBridge.address, '1', '0x', { from: user }).should.be.rejectedWith(ERROR_MSG)
     })
     it('should not let to transfer less than minPerTx', async () => {
       const owner = accounts[3]
@@ -631,12 +671,12 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       await token.transferOwnership(foreignBridge.address, { from: owner })
 
       await token
-        .transferAndCall(foreignBridge.address, valueLessThanMinPerTx, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, valueLessThanMinPerTx, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
       expect(await token.totalSupply()).to.be.bignumber.equal(oneEther)
       expect(await token.balanceOf(user)).to.be.bignumber.equal(oneEther)
 
-      await token.transferAndCall(foreignBridge.address, minPerTx, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, minPerTx, '0x', { from: user }).should.be.fulfilled
 
       expect(await token.totalSupply()).to.be.bignumber.equal(oneEther)
       expect(await token.balanceOf(user)).to.be.bignumber.equal(oneEther.sub(minPerTx))
@@ -645,6 +685,37 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       const events = await getEvents(foreignBridge, { event: 'UserRequestForAffirmation' })
       expect(events[0].returnValues.recipient).to.be.equal(user)
       expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(minPerTx)
+    })
+    it('should be able to specify a different receiver', async () => {
+      const owner = accounts[3]
+      const user = accounts[4]
+      const user2 = accounts[5]
+      token = await ERC677BridgeToken.new('TEST', 'TST', 18, { from: owner })
+      const foreignBridge = await ForeignBridgeErc677ToErc677.new()
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero
+      )
+      await token.mint(user, halfEther, { from: owner }).should.be.fulfilled
+      await token.transferOwnership(foreignBridge.address, { from: owner })
+      await token
+        .transferAndCall(foreignBridge.address, halfEther, ZERO_ADDRESS, { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      await token
+        .transferAndCall(foreignBridge.address, halfEther, '0x0000', { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      await token.transferAndCall(foreignBridge.address, halfEther, user2, { from: user }).should.be.fulfilled
+
+      expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)
+      const events = await getEvents(foreignBridge, { event: 'UserRequestForAffirmation' })
+      expect(events[0].returnValues.recipient).to.be.equal(user2)
+      expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(halfEther)
     })
   })
   describe('#decimalShift', async () => {
@@ -660,7 +731,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftTwo
       )
@@ -703,7 +775,8 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
         erc20Token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftTwo
       )
@@ -761,9 +834,9 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
 
       await token.mint(user, value, { from: owner }).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address, { from: owner })
-      await foreignBridge.onTokenTransfer(user, value, '0x00', { from: owner }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.onTokenTransfer(user, value, '0x', { from: owner }).should.be.rejectedWith(ERROR_MSG)
 
-      await token.transferAndCall(foreignBridge.address, value, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, value, '0x', { from: user }).should.be.fulfilled
       expect(await token.totalSupply()).to.be.bignumber.equal(value)
       expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)
       expect(await token.balanceOf(foreignBridge.address)).to.be.bignumber.equal(value)
@@ -771,6 +844,163 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       const events = await getEvents(foreignBridge, { event: 'UserRequestForAffirmation' })
       expect(events[0].returnValues.recipient).to.be.equal(user)
       expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(value)
+    })
+  })
+  describe('#relayTokens', () => {
+    const value = ether('0.25')
+    const user = accounts[7]
+    const recipient = accounts[8]
+    let foreignBridge
+    beforeEach(async () => {
+      foreignBridge = await ForeignBridge.new()
+      token = await ERC677BridgeToken.new('Some ERC20', 'RSZT', 18)
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero
+      )
+      await token.mint(user, ether('2'))
+    })
+    it('should allow to bridge tokens using approve tranferFrom', async () => {
+      // Given
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, value, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, 0, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      const { logs } = await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.fulfilled
+
+      // Then
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient,
+        value
+      })
+    })
+    it('should allow to call relayTokens without specifying the sender', async () => {
+      // Given
+      await foreignBridge.methods['relayTokens(address,uint256)'](recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, value, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,uint256)'](ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,uint256)'](foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,uint256)'](recipient, 0, { from: user }).should.be.rejectedWith(
+        ERROR_MSG
+      )
+      const { logs } = await foreignBridge.methods['relayTokens(address,uint256)'](recipient, value, { from: user })
+        .should.be.fulfilled
+
+      // Then
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient,
+        value
+      })
+    })
+    it('should not be able to transfer more than limit', async () => {
+      // Given
+      const userSupply = ether('2')
+      const bigValue = oneEther
+      const smallValue = ether('0.001')
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await token.approve(foreignBridge.address, userSupply, { from: user }).should.be.fulfilled
+
+      // When
+      // value < minPerTx
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, smallValue, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      // value > maxPerTx
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, bigValue, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, halfEther, { from: user })
+        .should.be.fulfilled
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, halfEther, { from: user })
+        .should.be.fulfilled
+      // totalSpentPerDay > dailyLimit
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, halfEther, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      // Then
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(oneEther)
+    })
+    it('should allow only sender to specify a different receiver', async () => {
+      // Given
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, oneEther, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, 0, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: recipient
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, user, value, { from: user }).should.be
+        .fulfilled
+      const { logs } = await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.fulfilled
+      const { logs: logsSecondTx } = await foreignBridge.methods['relayTokens(address,address,uint256)'](
+        user,
+        user,
+        value,
+        { from: recipient }
+      ).should.be.fulfilled
+
+      // Then
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient,
+        value
+      })
+      expectEventInLogs(logsSecondTx, 'UserRequestForAffirmation', {
+        recipient: user,
+        value
+      })
     })
   })
 })

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -1541,8 +1541,8 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const message = createMessage(recipient, value, transactionHash, homeBridge.address)
       const signature = await sign(validators[0], message)
 
-      const rewardAddressBalanceBefore = await token.balanceOf(rewards[0])
-      rewardAddressBalanceBefore.should.be.bignumber.equal('0')
+      const blockRewardBalanceBefore = await token.balanceOf(blockRewardContract.address)
+      blockRewardBalanceBefore.should.be.bignumber.equal('0')
 
       // When
       const { logs } = await homeBridge.submitSignature(signature, message, { from: validators[0] }).should.be.fulfilled
@@ -1561,8 +1561,11 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const feeDistributed = await blockRewardContract.feeAmount()
       feeDistributed.should.be.bignumber.equal(feeAmount)
 
-      const rewardAddressBalanceAfter = await token.balanceOf(rewards[0])
+      const rewardAddressBalanceAfter = await blockRewardContract.validatorRewardList(0)
       rewardAddressBalanceAfter.should.be.bignumber.equal(feeAmount)
+
+      const blockRewardBalanceAfter = await token.balanceOf(blockRewardContract.address)
+      blockRewardBalanceAfter.should.be.bignumber.equal(feeAmount)
     })
     it('should distribute fee to 3 validators', async () => {
       // Given
@@ -1608,9 +1611,9 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const feeDistributed = await blockRewardContract.feeAmount()
       feeDistributed.should.be.bignumber.equal(feeAmount)
 
-      const balanceRewardAddress1 = await token.balanceOf(rewards[0])
-      const balanceRewardAddress2 = await token.balanceOf(rewards[1])
-      const balanceRewardAddress3 = await token.balanceOf(rewards[2])
+      const balanceRewardAddress1 = await blockRewardContract.validatorRewardList(0)
+      const balanceRewardAddress2 = await blockRewardContract.validatorRewardList(1)
+      const balanceRewardAddress3 = await blockRewardContract.validatorRewardList(2)
 
       expect(balanceRewardAddress1.eq(feePerValidator) || balanceRewardAddress1.eq(feePerValidatorPlusDiff)).to.equal(
         true
@@ -1667,11 +1670,11 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const feeDistributed = await blockRewardContract.feeAmount()
       feeDistributed.should.be.bignumber.equal(feeAmount)
 
-      const balanceRewardAddress1 = await token.balanceOf(rewards[0])
-      const balanceRewardAddress2 = await token.balanceOf(rewards[1])
-      const balanceRewardAddress3 = await token.balanceOf(rewards[2])
-      const balanceRewardAddress4 = await token.balanceOf(rewards[3])
-      const balanceRewardAddress5 = await token.balanceOf(rewards[4])
+      const balanceRewardAddress1 = await blockRewardContract.validatorRewardList(0)
+      const balanceRewardAddress2 = await blockRewardContract.validatorRewardList(1)
+      const balanceRewardAddress3 = await blockRewardContract.validatorRewardList(2)
+      const balanceRewardAddress4 = await blockRewardContract.validatorRewardList(3)
+      const balanceRewardAddress5 = await blockRewardContract.validatorRewardList(4)
 
       balanceRewardAddress1.should.be.bignumber.equal(feePerValidator)
       balanceRewardAddress2.should.be.bignumber.equal(feePerValidator)
@@ -1754,7 +1757,7 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const feeDistributed = await blockRewardContract.feeAmount()
       feeDistributed.should.be.bignumber.equal(feeAmount)
 
-      const rewardAddressBalanceAfter = await token.balanceOf(rewards[0])
+      const rewardAddressBalanceAfter = await blockRewardContract.validatorRewardList(0)
       rewardAddressBalanceAfter.should.be.bignumber.equal(feeAmount)
 
       const recipientBalance = await token.balanceOf(recipient)
@@ -1811,9 +1814,9 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const recipientBalance = await token.balanceOf(recipient)
       recipientBalance.should.be.bignumber.equal(value)
 
-      const balanceRewardAddress1 = await token.balanceOf(rewards[0])
-      const balanceRewardAddress2 = await token.balanceOf(rewards[1])
-      const balanceRewardAddress3 = await token.balanceOf(rewards[2])
+      const balanceRewardAddress1 = await blockRewardContract.validatorRewardList(0)
+      const balanceRewardAddress2 = await blockRewardContract.validatorRewardList(1)
+      const balanceRewardAddress3 = await blockRewardContract.validatorRewardList(2)
 
       expect(balanceRewardAddress1.eq(feePerValidator) || balanceRewardAddress1.eq(feePerValidatorPlusDiff)).to.equal(
         true
@@ -1878,11 +1881,11 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       const recipientBalance = await token.balanceOf(recipient)
       recipientBalance.should.be.bignumber.equal(value)
 
-      const balanceRewardAddress1 = await token.balanceOf(rewards[0])
-      const balanceRewardAddress2 = await token.balanceOf(rewards[1])
-      const balanceRewardAddress3 = await token.balanceOf(rewards[2])
-      const balanceRewardAddress4 = await token.balanceOf(rewards[3])
-      const balanceRewardAddress5 = await token.balanceOf(rewards[4])
+      const balanceRewardAddress1 = await blockRewardContract.validatorRewardList(0)
+      const balanceRewardAddress2 = await blockRewardContract.validatorRewardList(1)
+      const balanceRewardAddress3 = await blockRewardContract.validatorRewardList(2)
+      const balanceRewardAddress4 = await blockRewardContract.validatorRewardList(3)
+      const balanceRewardAddress5 = await blockRewardContract.validatorRewardList(4)
 
       balanceRewardAddress1.should.be.bignumber.equal(feePerValidator)
       balanceRewardAddress2.should.be.bignumber.equal(feePerValidator)

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -1446,6 +1446,35 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       expect(events[0].returnValues.recipient).to.be.equal(user)
       expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(value)
     })
+    it('should be able to specify a different receiver', async () => {
+      // Given
+      const owner = accounts[0]
+      const user = accounts[4]
+      const user2 = accounts[5]
+      await homeBridge.initialize(
+        validatorContract.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        token.address,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        decimalShiftZero
+      ).should.be.fulfilled
+      const value = halfEther
+      await token.mint(user, value, { from: owner }).should.be.fulfilled
+
+      // When
+      await token
+        .transferAndCall(homeBridge.address, value, ZERO_ADDRESS, { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      await token.transferAndCall(homeBridge.address, value, user2, { from: user }).should.be.fulfilled
+
+      // Then
+      const events = await getEvents(homeBridge, { event: 'UserRequestForSignature' })
+      expect(events[0].returnValues.recipient).to.be.equal(user2)
+      expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(value)
+    })
     it('should trigger UserRequestForSignature with fee subtracted', async () => {
       // Given
       const homeBridge = await POSDAOHomeBridge.new()

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -1439,7 +1439,7 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       await token.mint(user, value, { from: owner }).should.be.fulfilled
 
       // When
-      await token.transferAndCall(homeBridge.address, value, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(homeBridge.address, value, '0x', { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(homeBridge, { event: 'UserRequestForSignature' })
@@ -1481,7 +1481,7 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       await token.mint(user, value, { from: owner }).should.be.fulfilled
 
       // When
-      await token.transferAndCall(homeBridge.address, value, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(homeBridge.address, value, '0x', { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(homeBridge, { event: 'UserRequestForSignature' })
@@ -1969,7 +1969,7 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
       await token.mint(user, value, { from: owner }).should.be.fulfilled
 
       // When
-      await token.transferAndCall(homeBridge.address, value, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(homeBridge.address, value, '0x', { from: user }).should.be.fulfilled
 
       // Then
       const events = await getEvents(homeBridge, { event: 'UserRequestForSignature' })

--- a/test/erc_to_native/foreign_bridge.test.js
+++ b/test/erc_to_native/foreign_bridge.test.js
@@ -14,7 +14,9 @@ const gasPrice = web3.utils.toWei('1', 'gwei')
 const oneEther = ether('1')
 const homeDailyLimit = oneEther
 const homeMaxPerTx = halfEther
+const dailyLimit = oneEther
 const maxPerTx = halfEther
+const minPerTx = ether('0.01')
 const ZERO = toBN(0)
 const decimalShiftZero = 0
 
@@ -23,13 +25,14 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
   let authorities
   let owner
   let token
+  let otherSideBridge
   before(async () => {
     validatorContract = await BridgeValidators.new()
     authorities = [accounts[1], accounts[2]]
     owner = accounts[0]
     await validatorContract.initialize(1, authorities, owner)
+    otherSideBridge = await ForeignBridge.new()
   })
-
   describe('#initialize', async () => {
     it('should initialize', async () => {
       token = await ERC677BridgeToken.new('Some ERC20', 'RSZT', 18)
@@ -42,92 +45,106 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       expect(await foreignBridge.requiredBlockConfirmations()).to.be.bignumber.equal(ZERO)
       expect(await foreignBridge.decimalShift()).to.be.bignumber.equal(ZERO)
 
-      await foreignBridge
-        .initialize(
-          ZERO_ADDRESS,
-          token.address,
-          requireBlockConfirmations,
-          gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await foreignBridge
-        .initialize(
-          validatorContract.address,
-          ZERO_ADDRESS,
-          requireBlockConfirmations,
-          gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await foreignBridge
-        .initialize(
-          validatorContract.address,
-          token.address,
-          0,
-          gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await foreignBridge
-        .initialize(
-          validatorContract.address,
-          token.address,
-          requireBlockConfirmations,
-          0,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await foreignBridge
-        .initialize(
-          validatorContract.address,
-          owner,
-          requireBlockConfirmations,
-          gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await foreignBridge
-        .initialize(
-          owner,
-          token.address,
-          requireBlockConfirmations,
-          gasPrice,
-          [maxPerTx, homeDailyLimit, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await foreignBridge
-        .initialize(
-          validatorContract.address,
-          token.address,
-          requireBlockConfirmations,
-          gasPrice,
-          [maxPerTx, halfEther, homeMaxPerTx],
-          owner,
-          decimalShiftZero
-        )
-        .should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.initialize(
+        ZERO_ADDRESS,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+      await foreignBridge.initialize(
+        validatorContract.address,
+        ZERO_ADDRESS,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        0,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        requireBlockConfirmations,
+        0,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+      await foreignBridge.initialize(
+        validatorContract.address,
+        owner,
+        requireBlockConfirmations,
+        gasPrice,
+        [maxPerTx, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+      await foreignBridge.initialize(
+        owner,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, minPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeMaxPerTx, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      ).should.be.rejected
+
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        '9',
+        ZERO_ADDRESS
+      ).should.be.rejected
 
       const { logs } = await foreignBridge.initialize(
         validatorContract.address,
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
-        '9'
+        '9',
+        otherSideBridge.address
       )
 
       expect(await foreignBridge.erc20token()).to.be.equal(token.address)
@@ -137,6 +154,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       expect(await foreignBridge.requiredBlockConfirmations()).to.be.bignumber.equal(
         requireBlockConfirmations.toString()
       )
+      expect(await foreignBridge.dailyLimit()).to.be.bignumber.equal(dailyLimit)
+      expect(await foreignBridge.maxPerTx()).to.be.bignumber.equal(maxPerTx)
+      expect(await foreignBridge.minPerTx()).to.be.bignumber.equal(minPerTx)
+      expect(await foreignBridge.executionDailyLimit()).to.be.bignumber.equal(homeDailyLimit)
+      expect(await foreignBridge.executionMaxPerTx()).to.be.bignumber.equal(homeMaxPerTx)
       expect(await foreignBridge.decimalShift()).to.be.bignumber.equal('9')
       expect(await foreignBridge.gasPrice()).to.be.bignumber.equal(gasPrice)
       const bridgeMode = '0x18762d46' // 4 bytes of keccak256('erc-to-native-core')
@@ -150,10 +172,10 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         requiredBlockConfirmations: toBN(requireBlockConfirmations)
       })
       expectEventInLogs(logs, 'GasPriceChanged', { gasPrice })
+      expectEventInLogs(logs, 'DailyLimitChanged', { newLimit: dailyLimit })
       expectEventInLogs(logs, 'ExecutionDailyLimitChanged', { newLimit: homeDailyLimit })
     })
   })
-
   describe('#executeSignatures', async () => {
     const value = ether('0.25')
     let foreignBridge
@@ -165,9 +187,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridge.address
       )
       await token.mint(foreignBridge.address, value)
     })
@@ -288,7 +312,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       await foreignBridge.executeSignatures([vrs3.v], [vrs3.r], [vrs3.s], message3).should.be.rejectedWith(ERROR_MSG)
     })
   })
-
   describe('#withdraw with 2 minimum signatures', async () => {
     let multisigValidatorContract
     let twoAuthorities
@@ -309,9 +332,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero,
+        otherSideBridge.address,
         { from: ownerOfValidatorContract }
       )
       await token.mint(foreignBridgeWithMultiSignatures.address, value)
@@ -375,9 +400,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         erc20Token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridge.address
       )
       await erc20Token.mint(foreignBridgeWithThreeSigs.address, value)
 
@@ -408,7 +435,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       true.should.be.equal(await foreignBridgeWithThreeSigs.relayedMessages(txHash))
     })
   })
-
   describe('#upgradeable', async () => {
     it('can be upgraded', async () => {
       const REQUIRED_NUMBER_OF_VALIDATORS = 1
@@ -436,9 +462,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridge.address
       )
 
       // Deploy V2
@@ -460,9 +488,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
           tokenAddress,
           requireBlockConfirmations,
           gasPrice,
-          ['2', '3', '2'],
+          ['3', '2', '1'],
+          ['3', '2'],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridge.address
         )
         .encodeABI()
 
@@ -473,7 +503,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       validatorsAddress.should.be.equal(await finalContract.validatorContract())
     })
   })
-
   describe('#claimTokens', async () => {
     it('can send erc20', async () => {
       const owner = accounts[0]
@@ -488,9 +517,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridge.address
       )
       const tokenSecond = await ERC677BridgeToken.new('Roman Token', 'RST', 18)
 
@@ -509,7 +540,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       expect(await tokenSecond.balanceOf(accounts[3])).to.be.bignumber.equal(halfEther)
     })
   })
-
   describe('#decimalShift', async () => {
     const decimalShiftTwo = 2
     it('Home to Foreign: withdraw with 1 signature with a decimalShift of 2', async () => {
@@ -530,9 +560,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftTwo
+        decimalShiftTwo,
+        otherSideBridge.address
       )
       await token.mint(foreignBridge.address, valueOnForeign)
 
@@ -575,9 +607,11 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         token.address,
         requireBlockConfirmations,
         gasPrice,
-        [maxPerTx, homeDailyLimit, homeMaxPerTx],
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftTwo,
+        otherSideBridge.address,
         { from: ownerOfValidatorContract }
       )
       await token.mint(foreignBridgeWithMultiSignatures.address, valueOnForeign)
@@ -609,6 +643,195 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
       const balanceAfterBridge = await token.balanceOf(foreignBridgeWithMultiSignatures.address)
       balanceAfterBridge.should.be.bignumber.equal(ZERO)
       true.should.be.equal(await foreignBridgeWithMultiSignatures.relayedMessages(txHash))
+    })
+  })
+  describe('#relayTokens', () => {
+    const value = ether('0.25')
+    const user = accounts[7]
+    const recipient = accounts[8]
+    let foreignBridge
+    beforeEach(async () => {
+      foreignBridge = await ForeignBridge.new()
+      token = await ERC677BridgeToken.new('Some ERC20', 'RSZT', 18)
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridge.address
+      )
+      await token.mint(user, ether('2'))
+    })
+    it('should allow to bridge tokens using approve and relayTokens', async () => {
+      // Given
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, value, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, user, 0, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      const { logs } = await foreignBridge.methods['relayTokens(address,address,uint256)'](user, user, value, {
+        from: user
+      }).should.be.fulfilled
+
+      // Then
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient: user,
+        value
+      })
+    })
+    it('should allow to bridge tokens using approve and relayTokens with different recipient', async () => {
+      // Given
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, value, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, 0, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      const { logs } = await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.fulfilled
+
+      // Then
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(value)
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient,
+        value
+      })
+    })
+    it('should allow only sender to specify a different receiver', async () => {
+      // Given
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, oneEther, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, 0, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: recipient
+      }).should.be.rejectedWith(ERROR_MSG)
+      const { logs } = await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, value, {
+        from: user
+      }).should.be.fulfilled
+      const { logs: logsSecondTx } = await foreignBridge.methods['relayTokens(address,address,uint256)'](
+        user,
+        user,
+        value,
+        { from: recipient }
+      ).should.be.fulfilled
+
+      // Then
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient,
+        value
+      })
+      expectEventInLogs(logsSecondTx, 'UserRequestForAffirmation', {
+        recipient: user,
+        value
+      })
+    })
+    it('should not be able to transfer more than limit', async () => {
+      // Given
+      const userSupply = ether('2')
+      const bigValue = oneEther
+      const smallValue = ether('0.001')
+      const currentDay = await foreignBridge.getCurrentDay()
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await token.approve(foreignBridge.address, userSupply, { from: user }).should.be.fulfilled
+
+      // When
+      // value < minPerTx
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, smallValue, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      // value > maxPerTx
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, bigValue, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, halfEther, { from: user })
+        .should.be.fulfilled
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, halfEther, { from: user })
+        .should.be.fulfilled
+      // totalSpentPerDay > dailyLimit
+      await foreignBridge.methods['relayTokens(address,address,uint256)'](user, recipient, halfEther, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      // Then
+      expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(oneEther)
+    })
+    it('should allow to call relayTokens without specifying the sender', async () => {
+      // Given
+      await foreignBridge.methods['relayTokens(address,uint256)'](recipient, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+
+      await token.approve(foreignBridge.address, value, { from: user }).should.be.fulfilled
+
+      // When
+      await foreignBridge.methods['relayTokens(address,uint256)'](ZERO_ADDRESS, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,uint256)'](foreignBridge.address, value, {
+        from: user
+      }).should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge.methods['relayTokens(address,uint256)'](recipient, 0, { from: user }).should.be.rejectedWith(
+        ERROR_MSG
+      )
+      const { logs } = await foreignBridge.methods['relayTokens(address,uint256)'](recipient, value, { from: user })
+        .should.be.fulfilled
+
+      // Then
+      expectEventInLogs(logs, 'UserRequestForAffirmation', {
+        recipient,
+        value
+      })
     })
   })
 })

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -36,7 +36,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
     owner = accounts[0]
     await validatorContract.initialize(1, authorities, owner)
   })
-
   describe('#initialize', async () => {
     beforeEach(async () => {
       homeContract = await HomeBridge.new()
@@ -291,7 +290,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       true.should.be.equal(await homeContract.isInitialized())
     })
   })
-
   describe('#rewardableInitialize', async () => {
     let feeManager
     let homeFee
@@ -535,7 +533,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       expect(await homeContract.getForeignFee()).to.be.bignumber.equals(newForeignFee)
     })
   })
-
   describe('#fallback', async () => {
     beforeEach(async () => {
       homeContract = await HomeBridge.new()
@@ -678,7 +675,143 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       burnt.should.be.bignumber.equal('2')
     })
   })
+  describe('#relayTokens', () => {
+    const recipient = accounts[7]
+    beforeEach(async () => {
+      homeContract = await HomeBridge.new()
+      await homeContract.initialize(
+        validatorContract.address,
+        ['3', '2', '1'],
+        gasPrice,
+        requireBlockConfirmations,
+        blockRewardContract.address,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        decimalShiftZero
+      )
+    })
+    it('should accept native coins and alternative receiver', async () => {
+      const currentDay = await homeContract.getCurrentDay()
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
 
+      await blockRewardContract.addMintedTotallyByBridge(10, homeContract.address)
+      const minted = await blockRewardContract.mintedTotallyByBridge(homeContract.address)
+      minted.should.be.bignumber.equal('10')
+
+      const { logs } = await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+
+      expectEventInLogs(logs, 'UserRequestForSignature', { recipient, value: toBN(1) })
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal('1')
+      expect(await homeContract.totalBurntCoins()).to.be.bignumber.equal('1')
+
+      const homeContractBalance = toBN(await web3.eth.getBalance(homeContract.address))
+      homeContractBalance.should.be.bignumber.equal(ZERO)
+    })
+    it('should accumulate burnt coins', async () => {
+      await blockRewardContract.addMintedTotallyByBridge(10, homeContract.address)
+
+      const currentDay = await homeContract.getCurrentDay()
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+      expect(await homeContract.totalBurntCoins()).to.be.bignumber.equal('1')
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+      expect(await homeContract.totalBurntCoins()).to.be.bignumber.equal('2')
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+      expect(await homeContract.totalBurntCoins()).to.be.bignumber.equal('3')
+
+      const homeContractBalance = toBN(await web3.eth.getBalance(homeContract.address))
+      homeContractBalance.should.be.bignumber.equal(ZERO)
+    })
+    it('doesnt let you send more than daily limit', async () => {
+      await blockRewardContract.addMintedTotallyByBridge(10, homeContract.address)
+
+      const currentDay = await homeContract.getCurrentDay()
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal('1')
+      expect(await homeContract.totalBurntCoins()).to.be.bignumber.equal('1')
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal('2')
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 2 }).should.be.rejectedWith(ERROR_MSG)
+
+      await homeContract.setDailyLimit(4).should.be.fulfilled
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 2 }).should.be.fulfilled
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal('4')
+      expect(await homeContract.totalBurntCoins()).to.be.bignumber.equal('4')
+    })
+    it('doesnt let you send more than max amount per tx', async () => {
+      await blockRewardContract.addMintedTotallyByBridge(200, homeContract.address)
+
+      await homeContract.relayTokens(recipient, {
+        from: accounts[1],
+        value: 1
+      }).should.be.fulfilled
+      await homeContract
+        .relayTokens(recipient, {
+          from: accounts[1],
+          value: 3
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+      await homeContract.setMaxPerTx(100).should.be.rejectedWith(ERROR_MSG)
+      await homeContract.setDailyLimit(100).should.be.fulfilled
+      await homeContract.setMaxPerTx(99).should.be.fulfilled
+      // meets max per tx and daily limit
+      await homeContract.relayTokens(recipient, {
+        from: accounts[1],
+        value: 99
+      }).should.be.fulfilled
+      // above daily limit
+      await homeContract
+        .relayTokens(recipient, {
+          from: accounts[1],
+          value: 1
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+    })
+    it('should not let to deposit less than minPerTx', async () => {
+      const newDailyLimit = 100
+      const newMaxPerTx = 50
+      const newMinPerTx = 20
+
+      await blockRewardContract.addMintedTotallyByBridge(200, homeContract.address)
+
+      await homeContract.setDailyLimit(newDailyLimit).should.be.fulfilled
+      await homeContract.setMaxPerTx(newMaxPerTx).should.be.fulfilled
+      await homeContract.setMinPerTx(newMinPerTx).should.be.fulfilled
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: newMinPerTx }).should.be.fulfilled
+      await homeContract
+        .relayTokens(recipient, { from: accounts[1], value: newMinPerTx - 1 })
+        .should.be.rejectedWith(ERROR_MSG)
+    })
+    it('should fail if not enough bridged tokens', async () => {
+      const initiallyMinted = await blockRewardContract.mintedTotallyByBridge(homeContract.address)
+      initiallyMinted.should.be.bignumber.equal(ZERO)
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.rejectedWith(ERROR_MSG)
+
+      await blockRewardContract.addMintedTotallyByBridge(2, homeContract.address)
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.fulfilled
+
+      await homeContract.relayTokens(recipient, { from: accounts[1], value: 1 }).should.be.rejectedWith(ERROR_MSG)
+
+      const minted = await blockRewardContract.mintedTotallyByBridge(homeContract.address)
+      const burnt = await homeContract.totalBurntCoins()
+
+      minted.should.be.bignumber.equal('2')
+      burnt.should.be.bignumber.equal('2')
+    })
+  })
   describe('#setting limits', async () => {
     let homeContract
     beforeEach(async () => {
@@ -747,7 +880,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       expect(await homeContract.executionDailyLimit()).to.be.bignumber.equal(newValue)
     })
   })
-
   describe('#executeAffirmation', async () => {
     let homeBridge
     beforeEach(async () => {
@@ -1056,7 +1188,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       newOutOfLimitAmount.should.be.bignumber.equal(oneEther)
     })
   })
-
   describe('#submitSignature', async () => {
     let validatorContractWith2Signatures
     let authoritiesThreeAccs
@@ -1225,7 +1356,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       logs[1].args.authorityResponsibleForRelay.should.be.equal(authoritiesThreeAccs[1])
     })
   })
-
   describe('#requiredMessageLength', async () => {
     beforeEach(async () => {
       homeContract = await HomeBridge.new()
@@ -1535,7 +1665,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       })
     })
   })
-
   describe('#feeManager', async () => {
     let homeBridge
     let rewardableValidators
@@ -1943,6 +2072,62 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
 
       // When
       const { logs } = await homeBridge.sendTransaction({ from: recipient, value }).should.be.fulfilled
+
+      // Then
+      expectEventInLogs(logs, 'UserRequestForSignature', {
+        recipient,
+        value: finalValue
+      })
+      const currentDay = await homeBridge.getCurrentDay()
+      value.should.be.bignumber.equal(await homeBridge.totalSpentPerDay(currentDay))
+      finalValue.should.be.bignumber.equal(await homeBridge.totalBurntCoins())
+      const homeBridgeBalance = await web3.eth.getBalance(homeBridge.address)
+      expect(toBN(homeBridgeBalance)).to.be.bignumber.equal(value.sub(finalValue))
+    })
+  })
+  describe('#feeManager_relayTokens', async () => {
+    let homeBridge
+    let rewardableValidators
+    const owner = accounts[9]
+    const validators = [accounts[1]]
+    const rewards = [accounts[2]]
+    const requiredSignatures = 1
+    beforeEach(async () => {
+      rewardableValidators = await RewardableValidators.new()
+      await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
+      const homeBridgeImpl = await HomeBridge.new()
+      const storageProxy = await EternalStorageProxy.new().should.be.fulfilled
+      await storageProxy.upgradeTo('1', homeBridgeImpl.address).should.be.fulfilled
+      homeBridge = await HomeBridge.at(storageProxy.address)
+      await homeBridge.initialize(
+        rewardableValidators.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        blockRewardContract.address,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        decimalShiftZero
+      ).should.be.fulfilled
+      await blockRewardContract.addMintedTotallyByBridge(oneEther, homeBridge.address)
+    })
+
+    it('should subtract fee from value', async () => {
+      // Given
+      // 0.1% fee
+      const value = halfEther
+      const recipient = accounts[8]
+      const sender = accounts[7]
+      const fee = 0.001
+      const feeInWei = ether(fee.toString())
+      const valueCalc = 0.5 * (1 - fee)
+      const finalValue = ether(valueCalc.toString())
+      const feeManager = await FeeManagerErcToNative.new()
+      await homeBridge.setFeeManagerContract(feeManager.address, { from: owner }).should.be.fulfilled
+      await homeBridge.setHomeFee(feeInWei, { from: owner }).should.be.fulfilled
+
+      // When
+      const { logs } = await homeBridge.relayTokens(recipient, { from: sender, value }).should.be.fulfilled
 
       // Then
       expectEventInLogs(logs, 'UserRequestForSignature', {
@@ -2589,6 +2774,62 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       expect(toBN(homeBridgeBalance)).to.be.bignumber.equal(ZERO)
     })
   })
+  describe('#feeManager_relayTokens_POSDAO', async () => {
+    let homeBridge
+    let rewardableValidators
+    const owner = accounts[9]
+    const validators = [accounts[1]]
+    const rewards = [accounts[2]]
+    const requiredSignatures = 1
+    beforeEach(async () => {
+      rewardableValidators = await RewardableValidators.new()
+      await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner).should.be.fulfilled
+      const homeBridgeImpl = await HomeBridge.new()
+      const storageProxy = await EternalStorageProxy.new().should.be.fulfilled
+      await storageProxy.upgradeTo('1', homeBridgeImpl.address).should.be.fulfilled
+      homeBridge = await HomeBridge.at(storageProxy.address)
+      await homeBridge.initialize(
+        rewardableValidators.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        blockRewardContract.address,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        decimalShiftZero
+      ).should.be.fulfilled
+      await blockRewardContract.addMintedTotallyByBridge(oneEther, homeBridge.address)
+    })
+
+    it('should subtract fee from value', async () => {
+      // Given
+      // 0.1% fee
+      const value = halfEther
+      const recipient = accounts[8]
+      const sender = accounts[7]
+      const fee = 0.001
+      const feeInWei = ether(fee.toString())
+      const feeManager = await FeeManagerErcToNativePOSDAO.new()
+      await homeBridge.setFeeManagerContract(feeManager.address, { from: owner }).should.be.fulfilled
+      await homeBridge.setHomeFee(feeInWei, { from: owner }).should.be.fulfilled
+
+      // When
+      const { logs } = await homeBridge.relayTokens(recipient, { from: sender, value }).should.be.fulfilled
+
+      // Then
+      const valueCalc = 0.5 * (1 - fee)
+      const finalValue = ether(valueCalc.toString())
+      expectEventInLogs(logs, 'UserRequestForSignature', {
+        recipient,
+        value: finalValue
+      })
+      const currentDay = await homeBridge.getCurrentDay()
+      value.should.be.bignumber.equal(await homeBridge.totalSpentPerDay(currentDay))
+      value.should.be.bignumber.equal(await homeBridge.totalBurntCoins())
+      const homeBridgeBalance = await web3.eth.getBalance(homeBridge.address)
+      expect(toBN(homeBridgeBalance)).to.be.bignumber.equal(ZERO)
+    })
+  })
   describe('#feeManager_submitSignature_POSDAO', async () => {
     it('should distribute fee to validator', async () => {
       // Initialize
@@ -2876,7 +3117,6 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       feeAmountBlockReward.should.be.bignumber.equal(feeAmount)
     })
   })
-
   describe('#decimals Shift', async () => {
     const decimalShiftTwo = 2
     it('Foreign to Home: test with 2 signatures required and decimal shift 2', async () => {

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -1,5 +1,6 @@
 const ForeignBridge = artifacts.require('ForeignBridgeNativeToErc.sol')
 const ForeignBridgeV2 = artifacts.require('ForeignBridgeV2.sol')
+const HomeBridge = artifacts.require('HomeBridgeNativeToErc.sol')
 const BridgeValidators = artifacts.require('BridgeValidators.sol')
 const EternalStorageProxy = artifacts.require('EternalStorageProxy.sol')
 const FeeManagerNativeToErc = artifacts.require('FeeManagerNativeToErc.sol')
@@ -26,11 +27,14 @@ contract('ForeignBridge', async accounts => {
   let authorities
   let owner
   let token
+  let otherSideBridgeAddress
   before(async () => {
     validatorContract = await BridgeValidators.new()
     authorities = [accounts[1], accounts[2]]
     owner = accounts[0]
     await validatorContract.initialize(1, authorities, owner)
+    const otherSideBridge = await HomeBridge.new()
+    otherSideBridgeAddress = otherSideBridge.address
   })
 
   describe('#initialize', async () => {
@@ -55,7 +59,8 @@ contract('ForeignBridge', async accounts => {
           requireBlockConfirmations,
           [homeDailyLimit, homeMaxPerTx],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -67,7 +72,8 @@ contract('ForeignBridge', async accounts => {
           requireBlockConfirmations,
           [homeDailyLimit, homeMaxPerTx],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -79,7 +85,8 @@ contract('ForeignBridge', async accounts => {
           requireBlockConfirmations,
           [homeDailyLimit, homeMaxPerTx],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -91,7 +98,8 @@ contract('ForeignBridge', async accounts => {
           gasPrice,
           [homeDailyLimit, homeMaxPerTx],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -103,7 +111,8 @@ contract('ForeignBridge', async accounts => {
           gasPrice,
           [homeDailyLimit, homeMaxPerTx],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -115,7 +124,8 @@ contract('ForeignBridge', async accounts => {
           0,
           [homeDailyLimit, homeMaxPerTx],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       const { logs } = await foreignBridge.initialize(
@@ -126,7 +136,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        '9'
+        '9',
+        otherSideBridgeAddress
       )
 
       expect(await foreignBridge.isInitialized()).to.be.equal(true)
@@ -169,7 +180,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.transferOwnership(foreignBridge.address)
     })
@@ -315,6 +327,7 @@ contract('ForeignBridge', async accounts => {
         [homeDailyLimit, homeMaxPerTx],
         owner,
         decimalShiftZero,
+        otherSideBridgeAddress,
         { from: ownerOfValidatorContract }
       )
       await token.transferOwnership(foreignBridgeWithMultiSignatures.address)
@@ -378,7 +391,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await erc20Token.transferOwnership(foreignBridgeWithThreeSigs.address)
 
@@ -426,7 +440,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await erc20Token.transferOwnership(foreignBridgeWithThreeSigs.address)
 
@@ -474,12 +489,13 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.mint(user, halfEther, { from: owner }).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address, { from: owner })
-      await foreignBridge.onTokenTransfer(user, halfEther, '0x00', { from: owner }).should.be.rejectedWith(ERROR_MSG)
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await foreignBridge.onTokenTransfer(user, halfEther, '0x', { from: owner }).should.be.rejectedWith(ERROR_MSG)
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
       expect(await token.totalSupply()).to.be.bignumber.equal(ZERO)
       expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)
     })
@@ -498,19 +514,20 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.mint(user, valueMoreThanLimit, { from: owner }).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address, { from: owner })
 
       await token
-        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
 
       valueMoreThanLimit.should.be.bignumber.equal(await token.totalSupply())
       valueMoreThanLimit.should.be.bignumber.equal(await token.balanceOf(user))
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
 
       expect(await token.totalSupply()).to.be.bignumber.equal('1')
       expect(await token.balanceOf(user)).to.be.bignumber.equal('1')
@@ -533,31 +550,31 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.mint(user, oneEther.add(toBN(1)), { from: owner }).should.be.fulfilled
 
       await token.transferOwnership(foreignBridge.address, { from: owner })
 
       await token
-        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
 
       oneEther.add(toBN(1)).should.be.bignumber.equal(await token.totalSupply())
       oneEther.add(toBN(1)).should.be.bignumber.equal(await token.balanceOf(user))
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
 
       valueMoreThanLimit.should.be.bignumber.equal(await token.totalSupply())
       valueMoreThanLimit.should.be.bignumber.equal(await token.balanceOf(user))
 
-      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x', { from: user }).should.be.fulfilled
 
       expect(await token.totalSupply()).to.be.bignumber.equal('1')
       expect(await token.balanceOf(user)).to.be.bignumber.equal('1')
-      await token.transferAndCall(foreignBridge.address, '1', '0x00', { from: user }).should.be.rejectedWith(ERROR_MSG)
+      await token.transferAndCall(foreignBridge.address, '1', '0x', { from: user }).should.be.rejectedWith(ERROR_MSG)
     })
-
     it('should not let to withdraw less than minPerTx', async () => {
       const owner = accounts[3]
       const user = accounts[4]
@@ -572,22 +589,55 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.mint(user, oneEther, { from: owner }).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address, { from: owner })
 
       await token
-        .transferAndCall(foreignBridge.address, valueLessThanMinPerTx, '0x00', { from: user })
+        .transferAndCall(foreignBridge.address, valueLessThanMinPerTx, '0x', { from: user })
         .should.be.rejectedWith(ERROR_MSG)
 
       oneEther.should.be.bignumber.equal(await token.totalSupply())
       oneEther.should.be.bignumber.equal(await token.balanceOf(user))
 
-      await token.transferAndCall(foreignBridge.address, minPerTx, '0x00', { from: user }).should.be.fulfilled
+      await token.transferAndCall(foreignBridge.address, minPerTx, '0x', { from: user }).should.be.fulfilled
 
       oneEther.sub(minPerTx).should.be.bignumber.equal(await token.totalSupply())
       oneEther.sub(minPerTx).should.be.bignumber.equal(await token.balanceOf(user))
+    })
+    it('should be able to specify a different receiver', async () => {
+      const owner = accounts[3]
+      const user = accounts[4]
+      const user2 = accounts[5]
+      token = await POA20.new('POA ERC20 Foundation', 'POA20', 18, { from: owner })
+      const foreignBridge = await ForeignBridge.new()
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridgeAddress
+      )
+      await token.mint(user, halfEther, { from: owner }).should.be.fulfilled
+      await token.transferOwnership(foreignBridge.address, { from: owner })
+      await token
+        .transferAndCall(foreignBridge.address, halfEther, otherSideBridgeAddress, { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      await token
+        .transferAndCall(foreignBridge.address, halfEther, '0x00', { from: user })
+        .should.be.rejectedWith(ERROR_MSG)
+      await token.transferAndCall(foreignBridge.address, halfEther, user2, { from: user }).should.be.fulfilled
+      expect(await token.totalSupply()).to.be.bignumber.equal(ZERO)
+      expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)
+      const events = await getEvents(foreignBridge, { event: 'UserRequestForAffirmation' })
+      expect(events[0].returnValues.recipient).to.be.equal(user2)
+      expect(toBN(events[0].returnValues.value)).to.be.bignumber.equal(halfEther)
     })
   })
 
@@ -604,7 +654,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.transferOwnership(foreignBridge.address)
     })
@@ -657,7 +708,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.transferOwnership(foreignBridgeProxy.address).should.be.fulfilled
 
@@ -687,7 +739,8 @@ contract('ForeignBridge', async accounts => {
           requireBlockConfirmations,
           ['3', '2'],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .encodeABI()
       await storageProxy.upgradeToAndCall('1', foreignBridge.address, data).should.be.fulfilled
@@ -712,7 +765,8 @@ contract('ForeignBridge', async accounts => {
           requireBlockConfirmations,
           ['3', '2'],
           owner,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .encodeABI()
       await storageProxy.upgradeToAndCall('1', foreignBridge.address, data).should.be.fulfilled
@@ -736,7 +790,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.transferOwnership(foreignBridge.address)
 
@@ -768,7 +823,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
       await token.transferOwnership(foreignBridge.address)
 
@@ -800,7 +856,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       )
 
       const tokenMock = await NoReturnTransferTokenMock.new()
@@ -854,7 +911,8 @@ contract('ForeignBridge', async accounts => {
           owner,
           feeManager.address,
           homeFee,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -868,7 +926,8 @@ contract('ForeignBridge', async accounts => {
           owner,
           feeManager.address,
           homeFee,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -882,7 +941,8 @@ contract('ForeignBridge', async accounts => {
           owner,
           feeManager.address,
           homeFee,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -896,7 +956,8 @@ contract('ForeignBridge', async accounts => {
           owner,
           feeManager.address,
           homeFee,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -910,7 +971,8 @@ contract('ForeignBridge', async accounts => {
           owner,
           feeManager.address,
           homeFee,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge
@@ -924,7 +986,8 @@ contract('ForeignBridge', async accounts => {
           owner,
           ZERO_ADDRESS,
           homeFee,
-          decimalShiftZero
+          decimalShiftZero,
+          otherSideBridgeAddress
         )
         .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge.rewardableInitialize(
@@ -937,7 +1000,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         homeFee,
-        '9'
+        '9',
+        otherSideBridgeAddress
       ).should.be.fulfilled
 
       expect(await foreignBridge.isInitialized()).to.be.equal(true)
@@ -974,7 +1038,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         homeFee,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
 
       // Given
@@ -999,7 +1064,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         homeFee,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
 
       // Given
@@ -1023,7 +1089,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         homeFee,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
 
       // Given
@@ -1056,7 +1123,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         homeFee,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
 
       // Then
@@ -1098,7 +1166,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         feeInWei,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address)
 
@@ -1156,7 +1225,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         feeInWei,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address)
 
@@ -1242,7 +1312,8 @@ contract('ForeignBridge', async accounts => {
         owner,
         feeManager.address,
         feeInWei,
-        decimalShiftZero
+        decimalShiftZero,
+        otherSideBridgeAddress
       ).should.be.fulfilled
       await token.transferOwnership(foreignBridge.address)
 
@@ -1322,7 +1393,8 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftTwo
+        decimalShiftTwo,
+        otherSideBridgeAddress
       )
       await erc20Token.transferOwnership(foreignBridgeWithThreeSigs.address)
 
@@ -1371,12 +1443,13 @@ contract('ForeignBridge', async accounts => {
         requireBlockConfirmations,
         [homeDailyLimit, homeMaxPerTx],
         owner,
-        decimalShiftTwo
+        decimalShiftTwo,
+        otherSideBridgeAddress
       )
       await token.mint(user, value, { from: owner }).should.be.fulfilled
       expect(await token.balanceOf(user)).to.be.bignumber.equal(value)
       await token.transferOwnership(foreignBridge.address, { from: owner })
-      const { logs } = await token.transferAndCall(foreignBridge.address, value, '0x00', { from: user })
+      const { logs } = await token.transferAndCall(foreignBridge.address, value, '0x', { from: user })
       logs[0].event.should.be.equal('Transfer')
       logs[0].args.value.should.be.bignumber.equal(value)
       expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)

--- a/test/native_to_erc/home_bridge_test.js
+++ b/test/native_to_erc/home_bridge_test.js
@@ -364,6 +364,98 @@ contract('HomeBridge', async accounts => {
     })
   })
 
+  describe('#relayTokens', async () => {
+    const user = accounts[1]
+    const user2 = accounts[2]
+    beforeEach(async () => {
+      homeContract = await HomeBridge.new()
+      await homeContract.initialize(
+        validatorContract.address,
+        ['3', '2', '1'],
+        gasPrice,
+        requireBlockConfirmations,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        decimalShiftZero
+      )
+    })
+    it('should accept native coins and alternative receiver', async () => {
+      const currentDay = await homeContract.getCurrentDay()
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal(ZERO)
+
+      const { logs } = await homeContract.relayTokens(user2, {
+        from: user,
+        value: 1
+      }).should.be.fulfilled
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal('1')
+
+      expectEventInLogs(logs, 'UserRequestForSignature', { recipient: user2, value: toBN(1) })
+
+      await homeContract
+        .relayTokens(user2, {
+          from: user,
+          value: 3
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+
+      await homeContract.setDailyLimit(4).should.be.fulfilled
+      await homeContract.relayTokens(user2, {
+        from: user,
+        value: 1
+      }).should.be.fulfilled
+
+      expect(await homeContract.totalSpentPerDay(currentDay)).to.be.bignumber.equal('2')
+    })
+
+    it('doesnt let you send more than max amount per tx', async () => {
+      await homeContract.relayTokens(user2, {
+        from: user,
+        value: 1
+      }).should.be.fulfilled
+      await homeContract
+        .relayTokens(user2, {
+          from: user,
+          value: 3
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+      await homeContract.setMaxPerTx(100).should.be.rejectedWith(ERROR_MSG)
+      await homeContract.setDailyLimit(100).should.be.fulfilled
+      await homeContract.setMaxPerTx(99).should.be.fulfilled
+      // meets max per tx and daily limit
+      await homeContract.relayTokens(user2, {
+        from: user,
+        value: 99
+      }).should.be.fulfilled
+      // above daily limit
+      await homeContract
+        .relayTokens(user2, {
+          from: user,
+          value: 1
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+    })
+
+    it('should not let to deposit less than minPerTx', async () => {
+      const newDailyLimit = 100
+      const newMaxPerTx = 50
+      const newMinPerTx = 20
+      await homeContract.setDailyLimit(newDailyLimit).should.be.fulfilled
+      await homeContract.setMaxPerTx(newMaxPerTx).should.be.fulfilled
+      await homeContract.setMinPerTx(newMinPerTx).should.be.fulfilled
+
+      await homeContract.relayTokens(user2, {
+        from: user,
+        value: newMinPerTx
+      }).should.be.fulfilled
+      await homeContract
+        .relayTokens(user2, {
+          from: user,
+          value: newMinPerTx - 1
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+    })
+  })
+
   describe('#setting limits', async () => {
     let homeContract
     beforeEach(async () => {
@@ -1281,6 +1373,55 @@ contract('HomeBridge', async accounts => {
     })
   })
 
+  describe('#feeManager_OneDirection_relayRequest', () => {
+    it('should not subtract fee from value', async () => {
+      // Initialize
+      const user = accounts[0]
+      const user2 = accounts[4]
+      const owner = accounts[9]
+      const validators = [accounts[1]]
+      const rewards = [accounts[2]]
+      const requiredSignatures = 1
+      const rewardableValidators = await RewardableValidators.new()
+      const homeBridge = await HomeBridge.new()
+      await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner, {
+        from: owner
+      }).should.be.fulfilled
+      const feeManager = await FeeManagerNativeToErc.new()
+
+      // Given
+      // 0.1% fee
+      const fee = 0.001
+      const feeInWei = ether(fee.toString())
+      const notUsedFee = ZERO
+      const value = halfEther
+
+      await homeBridge.rewardableInitialize(
+        rewardableValidators.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        feeManager.address,
+        [notUsedFee, feeInWei],
+        decimalShiftZero
+      ).should.be.fulfilled
+
+      // When
+      const { logs } = await homeBridge.relayTokens(user2, {
+        from: user,
+        value
+      }).should.be.fulfilled
+
+      // Then
+      expectEventInLogs(logs, 'UserRequestForSignature', {
+        recipient: user2,
+        value
+      })
+    })
+  })
+
   describe('#feeManager_OneDirection_submitSignature', () => {
     it('should not distribute fee to validator', async () => {
       // Initialize
@@ -1654,6 +1795,56 @@ contract('HomeBridge', async accounts => {
       const finalValue = ether(valueCalc.toString())
       expectEventInLogs(logs, 'UserRequestForSignature', {
         recipient: user,
+        value: finalValue
+      })
+    })
+  })
+
+  describe('#feeManager_BothDirections_relayRequest', () => {
+    it('should subtract fee from value', async () => {
+      // Initialize
+      const user = accounts[0]
+      const user2 = accounts[4]
+      const owner = accounts[9]
+      const validators = [accounts[1]]
+      const rewards = [accounts[2]]
+      const requiredSignatures = 1
+      const rewardableValidators = await RewardableValidators.new()
+      const homeBridge = await HomeBridge.new()
+      await rewardableValidators.initialize(requiredSignatures, validators, rewards, owner, {
+        from: owner
+      }).should.be.fulfilled
+      const feeManager = await FeeManagerNativeToErcBothDirections.new()
+
+      // Given
+      // 0.1% fee
+      const fee = 0.001
+      const feeInWei = ether(fee.toString())
+      const value = halfEther
+
+      await homeBridge.rewardableInitialize(
+        rewardableValidators.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        [foreignDailyLimit, foreignMaxPerTx],
+        owner,
+        feeManager.address,
+        [feeInWei, feeInWei],
+        decimalShiftZero
+      ).should.be.fulfilled
+
+      // When
+      const { logs } = await homeBridge.relayTokens(user2, {
+        from: user,
+        value
+      }).should.be.fulfilled
+
+      // Then
+      const valueCalc = 0.5 * (1 - fee)
+      const finalValue = ether(valueCalc.toString())
+      expectEventInLogs(logs, 'UserRequestForSignature', {
+        recipient: user2,
         value: finalValue
       })
     })

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -247,7 +247,8 @@ async function testERC677BridgeToken(accounts, rewardable) {
         requireBlockConfirmations,
         [executionDailyLimit, executionMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        homeErcToErcContract.address
       )
     })
     it('sends tokens to recipient', async () => {
@@ -424,7 +425,8 @@ async function testERC677BridgeToken(accounts, rewardable) {
         requireBlockConfirmations,
         [executionDailyLimit, executionMaxPerTx],
         owner,
-        decimalShiftZero
+        decimalShiftZero,
+        homeErcToErcContract.address
       )
     })
     it('calls contractFallback', async () => {

--- a/test/poa20_test.js
+++ b/test/poa20_test.js
@@ -156,47 +156,39 @@ async function testERC677BridgeToken(accounts, rewardable) {
     describe('#mintReward', async () => {
       it('can only be called by BlockReward contract', async () => {
         await token.setBlockRewardContractMock(accounts[2]).should.be.fulfilled
-        await token.mintReward([], [], { from: user }).should.be.rejectedWith(ERROR_MSG)
-        await token.mintReward([], [], { from: accounts[2] }).should.be.fulfilled
+        await token.mintReward(1, { from: user }).should.be.rejectedWith(ERROR_MSG)
+        await token.mintReward(1, { from: accounts[2] }).should.be.fulfilled
       })
-      it('should increase totalSupply and balances', async () => {
-        const user1 = accounts[1]
-        const user2 = accounts[2]
-        const user3 = accounts[3]
-
+      it('should increase totalSupply and balance', async () => {
         expect(await token.totalSupply()).to.be.bignumber.equal(ZERO)
-        expect(await token.balanceOf(user1)).to.be.bignumber.equal(ZERO)
-        expect(await token.balanceOf(user2)).to.be.bignumber.equal(ZERO)
-        expect(await token.balanceOf(user3)).to.be.bignumber.equal(ZERO)
+        expect(await token.balanceOf(user)).to.be.bignumber.equal(ZERO)
 
-        await token.setBlockRewardContractMock(accounts[4]).should.be.fulfilled
-        await token.mintReward([user1, user2, user3], [100, 200, 300], { from: accounts[4] }).should.be.fulfilled
+        await token.setBlockRewardContractMock(user).should.be.fulfilled
+        await token.mintReward(100, { from: user }).should.be.fulfilled
 
-        expect(await token.totalSupply()).to.be.bignumber.equal('600')
-        expect(await token.balanceOf(user1)).to.be.bignumber.equal('100')
-        expect(await token.balanceOf(user2)).to.be.bignumber.equal('200')
-        expect(await token.balanceOf(user3)).to.be.bignumber.equal('300')
+        expect(await token.totalSupply()).to.be.bignumber.equal('100')
+        expect(await token.balanceOf(user)).to.be.bignumber.equal('100')
       })
     })
 
     describe('#stake', async () => {
       it('can only be called by Staking contract', async () => {
-        await token.setBlockRewardContractMock(accounts[2]).should.be.fulfilled
-        await token.mintReward([user], ['100'], { from: accounts[2] }).should.be.fulfilled
-        await token.setStakingContractMock(accounts[3]).should.be.fulfilled
-        await token.stake(user, '100', { from: accounts[4] }).should.be.rejectedWith(ERROR_MSG)
-        await token.stake(user, '100', { from: accounts[3] }).should.be.fulfilled
+        await token.setBlockRewardContractMock(user).should.be.fulfilled
+        await token.mintReward('100', { from: user }).should.be.fulfilled
+        await token.setStakingContractMock(accounts[4]).should.be.fulfilled
+        await token.stake(user, '100', { from: accounts[3] }).should.be.rejectedWith(ERROR_MSG)
+        await token.stake(user, '100', { from: accounts[4] }).should.be.fulfilled
       })
       it("should revert if user doesn't have enough balance", async () => {
-        await token.setBlockRewardContractMock(accounts[2]).should.be.fulfilled
-        await token.mintReward([user], ['99'], { from: accounts[2] }).should.be.fulfilled
+        await token.setBlockRewardContractMock(user).should.be.fulfilled
+        await token.mintReward('99', { from: user }).should.be.fulfilled
         expect(await token.balanceOf(user)).to.be.bignumber.equal('99')
         await token.setStakingContractMock(accounts[3]).should.be.fulfilled
         await token.stake(user, '100', { from: accounts[3] }).should.be.rejectedWith(ERROR_MSG_OPCODE)
       })
       it("should decrease user's balance and increase Staking's balance", async () => {
-        await token.setBlockRewardContractMock(accounts[2]).should.be.fulfilled
-        await token.mintReward([user], ['100'], { from: accounts[2] }).should.be.fulfilled
+        await token.setBlockRewardContractMock(user).should.be.fulfilled
+        await token.mintReward('100', { from: user }).should.be.fulfilled
         expect(await token.balanceOf(user)).to.be.bignumber.equal('100')
         expect(await token.balanceOf(accounts[3])).to.be.bignumber.equal(ZERO)
         await token.setStakingContractMock(accounts[3]).should.be.fulfilled
@@ -324,6 +316,15 @@ async function testERC677BridgeToken(accounts, rewardable) {
     })
 
     if (rewardable) {
+      it('fail to send tokens to BlockReward contract directly', async () => {
+        const amount = ether('1')
+        const blockRewardContractAddress = accounts[2]
+        const arbitraryAccountAddress = accounts[3]
+        await token.setBlockRewardContractMock(blockRewardContractAddress, { from: owner }).should.be.fulfilled
+        await token.mint(user, amount, { from: owner }).should.be.fulfilled
+        await token.transfer(blockRewardContractAddress, amount, { from: user }).should.be.rejectedWith(ERROR_MSG)
+        await token.transfer(arbitraryAccountAddress, amount, { from: user }).should.be.fulfilled
+      })
       it('fail to send tokens to Staking contract directly', async () => {
         const amount = ether('1')
         const stakingContractAddress = accounts[2]
@@ -356,6 +357,19 @@ async function testERC677BridgeToken(accounts, rewardable) {
       expect(await receiver.data()).to.be.equal(null)
     })
     if (rewardable) {
+      it('fail to send tokens to BlockReward contract directly', async () => {
+        const amount = ether('1')
+        const user2 = accounts[2]
+        const blockRewardContractAddress = accounts[3]
+        const arbitraryAccountAddress = accounts[4]
+        await token.setBlockRewardContractMock(blockRewardContractAddress, { from: owner }).should.be.fulfilled
+        await token.mint(user, amount, { from: owner }).should.be.fulfilled
+        await token.approve(user2, amount, { from: user }).should.be.fulfilled
+        await token
+          .transferFrom(user, blockRewardContractAddress, amount, { from: user2 })
+          .should.be.rejectedWith(ERROR_MSG)
+        await token.transferFrom(user, arbitraryAccountAddress, amount, { from: user2 }).should.be.fulfilled
+      })
       it('fail to send tokens to Staking contract directly', async () => {
         const amount = ether('1')
         const user2 = accounts[2]


### PR DESCRIPTION
This merge contains the following set of improvements and fixes:

  * [Improvement] Remove deployed at block information in mediators contracts (#292), closes #291
  * [Improvement] Use hex-identifiers directly instead of runtime hash calculation (#303)
  * [Improvement] Simplify mintReward function (#304)
  * Closes #295 (Alternative receiver for TokenBridge transfer operations) that was addressed by
    * [Improvement] Add alternative receiver for transfer in erc20 to erc20 mode (#305), closes #298
    * [Improvement] Add alternative receiver for transfer in native to erc20 mode (#302), closes #297
    * [Improvement] Add alternative receiver for ERC677-to-ERC677 on top of AMB (#301), closes #299
    * [Improvement] Add alternative receiver for transfer in erc20 to native mode (#294), closes #296
  * [Improvement] Add method to migrate from SCD to MCD (#311), closes #310
  * [Fix] Documentation typos (#289, #290)
  * [Fix] setTotalSpentPerDay called twice in AMB-ERC-TO-ERC (#309)
  * [Fix] Update interfaces version (#314), closes #313