### PR TITLE
Updated checks in setMinPerTx and setMaxPerTx

### DIFF
--- a/contracts/upgradeable_contracts/BasicTokenBridge.sol
+++ b/contracts/upgradeable_contracts/BasicTokenBridge.sol
@@ -90,12 +90,12 @@ contract BasicTokenBridge is EternalStorage, Ownable {
     }
 
     function setMaxPerTx(uint256 _maxPerTx) external onlyOwner {
-        require(_maxPerTx < dailyLimit());
+        require(_maxPerTx == 0 || (_maxPerTx > minPerTx() && _maxPerTx < dailyLimit()));
         uintStorage[MAX_PER_TX] = _maxPerTx;
     }
 
     function setMinPerTx(uint256 _minPerTx) external onlyOwner {
-        require(_minPerTx < dailyLimit() && _minPerTx < maxPerTx());
+        require(_minPerTx > 0 && _minPerTx < dailyLimit() && _minPerTx < maxPerTx());
         uintStorage[MIN_PER_TX] = _minPerTx;
     }
 }

--- a/test/erc_to_native/home_bridge.test.js
+++ b/test/erc_to_native/home_bridge.test.js
@@ -845,6 +845,13 @@ contract('HomeBridge_ERC20_to_Native', async accounts => {
       minPerTx.should.be.bignumber.equal(toBN(1))
     })
 
+    it('setMaxPerTx allows to set limit to zero', async () => {
+      await homeContract.setMaxPerTx(0, { from: owner }).should.be.fulfilled
+
+      const maxPerTx = await homeContract.maxPerTx()
+      maxPerTx.should.be.bignumber.equal(ZERO)
+    })
+
     it('setExecutionMaxPerTx allows to set only to owner and cannot be more than execution daily limit', async () => {
       const newValue = ether('0.3')
 


### PR DESCRIPTION
Closes #322 
`setMaxPerTx` now allows to set `0` limit in order to temporarily stop the bridge. Otherwise, if not `0`, new max limit should be greater than `minPerTx()`.
`setMinPerTx` additionally checks that new limit is positive.