### PR TITLE
Added Initialize functions access control modifier

### DIFF
--- a/contracts/upgradeability/ClassicEternalStorageProxy.sol
+++ b/contracts/upgradeability/ClassicEternalStorageProxy.sol
@@ -1,9 +1,8 @@
 pragma solidity 0.4.24;
 
-import "./EternalStorage.sol";
-import "./OwnedUpgradeabilityProxy.sol";
+import "./EternalStorageProxy.sol";
 
-contract ClassicEternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {
+contract ClassicEternalStorageProxy is EternalStorageProxy {
     // solhint-disable-next-line no-complex-fallback
     function() public payable {
         address _impl = implementation();

--- a/contracts/upgradeability/EternalStorageProxy.sol
+++ b/contracts/upgradeability/EternalStorageProxy.sol
@@ -10,11 +10,4 @@ import "./OwnedUpgradeabilityProxy.sol";
  * authorization control functionalities
  */
 // solhint-disable-next-line no-empty-blocks
-contract EternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {
-    bytes32 internal constant OWNER = 0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0; // keccak256(abi.encodePacked("owner"))
-
-    constructor() public {
-        // set initial owner in proxy storage to contract deployer
-        addressStorage[OWNER] = msg.sender;
-    }
-}
+contract EternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {}

--- a/contracts/upgradeability/EternalStorageProxy.sol
+++ b/contracts/upgradeability/EternalStorageProxy.sol
@@ -10,4 +10,11 @@ import "./OwnedUpgradeabilityProxy.sol";
  * authorization control functionalities
  */
 // solhint-disable-next-line no-empty-blocks
-contract EternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {}
+contract EternalStorageProxy is EternalStorage, OwnedUpgradeabilityProxy {
+    bytes32 internal constant OWNER = 0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0; // keccak256(abi.encodePacked("owner"))
+
+    constructor() public {
+        // set initial owner in proxy storage to contract deployer
+        addressStorage[OWNER] = msg.sender;
+    }
+}

--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -5,6 +5,7 @@ import "./BaseBridgeValidators.sol";
 contract BridgeValidators is BaseBridgeValidators {
     function initialize(uint256 _requiredSignatures, address[] _initialValidators, address _owner)
         external
+        onlyRelevantSender
         returns (bool)
     {
         require(!isInitialized());

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.4.24;
 
 import "../upgradeability/EternalStorage.sol";
+import "../interfaces/IUpgradeabilityOwnerStorage.sol";
 
 /**
  * @title Ownable
@@ -27,10 +28,11 @@ contract Ownable is EternalStorage {
     * @dev Throws if called by any account other than contract itself or owner.
     */
     modifier onlyRelevantSender() {
+        // proxy owner if used through proxy, address(0) otherwise
         require(
-            msg.sender == address(this) || // covers calls through upgradeAndCall proxy method
-                owner() == address(0) || //   covers usage without calling through storage proxy
-                msg.sender == owner() //      covers usage through regular proxy calls
+            !address(this).call(abi.encodeWithSignature("upgradeabilityOwner()")) || // covers usage without calling through storage proxy
+                msg.sender == IUpgradeabilityOwnerStorage(this).upgradeabilityOwner() || // covers usage through regular proxy calls
+                msg.sender == address(this) // covers calls through upgradeAndCall proxy method
         );
         /* solcov ignore next */
         _;

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -8,6 +8,8 @@ import "../interfaces/IUpgradeabilityOwnerStorage.sol";
  * @dev This contract has an owner address providing basic authorization control
  */
 contract Ownable is EternalStorage {
+    bytes4 internal constant UPGRADEABILITY_OWNER = 0x6fde8202; // upgradeabilityOwner()
+
     /**
     * @dev Event to show ownership has been transferred
     * @param previousOwner representing the address of the previous owner
@@ -30,7 +32,7 @@ contract Ownable is EternalStorage {
     modifier onlyRelevantSender() {
         // proxy owner if used through proxy, address(0) otherwise
         require(
-            !address(this).call(abi.encodeWithSignature("upgradeabilityOwner()")) || // covers usage without calling through storage proxy
+            !address(this).call(abi.encodeWithSelector(UPGRADEABILITY_OWNER)) || // covers usage without calling through storage proxy
                 msg.sender == IUpgradeabilityOwnerStorage(this).upgradeabilityOwner() || // covers usage through regular proxy calls
                 msg.sender == address(this) // covers calls through upgradeAndCall proxy method
         );

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -23,6 +23,19 @@ contract Ownable is EternalStorage {
         _;
     }
 
+    /**
+    * @dev Throws if called by any account other than contract itself or owner.
+    */
+    modifier onlyRelevantSender() {
+        require(
+            msg.sender == address(this) || // covers calls through upgradeAndCall proxy method
+                owner() == address(0) || //   covers usage without calling through storage proxy
+                msg.sender == owner() //      covers usage through regular proxy calls
+        );
+        /* solcov ignore next */
+        _;
+    }
+
     bytes32 internal constant OWNER = 0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0; // keccak256(abi.encodePacked("owner"))
 
     /**

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -8,7 +8,7 @@ contract RewardableValidators is BaseBridgeValidators {
         address[] _initialValidators,
         address[] _initialRewards,
         address _owner
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
         require(_owner != address(0));
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -8,7 +8,7 @@ contract RewardableValidators is BaseBridgeValidators {
         address[] _initialValidators,
         address[] _initialRewards,
         address _owner
-    ) public returns (bool) {
+    ) external returns (bool) {
         require(!isInitialized());
         require(_owner != address(0));
         setOwner(_owner);

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -38,7 +38,7 @@ contract BasicAMBErc677ToErc677 is
         uint256 _requestGasLimit,
         uint256 _decimalShift,
         address _owner
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
         require(
             _dailyLimitMaxPerTxMinPerTxArray[2] > 0 && // _minPerTx > 0

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
@@ -11,7 +11,7 @@ contract BasicAMB is BasicBridge {
         uint256 _gasPrice,
         uint256 _requiredBlockConfirmations,
         address _owner
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
         require(_validatorContract != address(0) && AddressUtils.isContract(_validatorContract));
         require(_gasPrice > 0);

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
@@ -11,7 +11,7 @@ contract BasicAMB is BasicBridge {
         uint256 _gasPrice,
         uint256 _requiredBlockConfirmations,
         address _owner
-    ) public returns (bool) {
+    ) external returns (bool) {
         require(!isInitialized());
         require(_validatorContract != address(0) && AddressUtils.isContract(_validatorContract));
         require(_gasPrice > 0);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErc677ToErc677.sol
@@ -13,7 +13,7 @@ contract ForeignBridgeErc677ToErc677 is ERC677Bridge, BasicForeignBridgeErcToErc
         uint256[] _homeDailyLimitHomeMaxPerTxArray, // [ 0 = _homeDailyLimit, 1 = _homeMaxPerTx ]
         address _owner,
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _erc20token,

--- a/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/ForeignBridgeErcToErc.sol
@@ -13,7 +13,7 @@ contract ForeignBridgeErcToErc is BasicForeignBridgeErcToErc, ERC20Bridge {
         uint256[] _homeDailyLimitHomeMaxPerTxArray, // [ 0 = _homeDailyLimit, 1 = _homeMaxPerTx ]
         address _owner,
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _erc20token,

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -24,7 +24,7 @@ contract HomeBridgeErcToErc is
         uint256[] _foreignDailyLimitForeignMaxPerTxArray, // [ 0 = _foreignDailyLimit, 1 = _foreignMaxPerTx ]
         address _owner,
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,
@@ -51,7 +51,7 @@ contract HomeBridgeErcToErc is
         address _feeManager,
         uint256[] _homeFeeForeignFeeArray, // [ 0 = _homeFee, 1 = _foreignFee ]
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _rewardableInitialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErcPOSDAO.sol
@@ -18,7 +18,7 @@ contract HomeBridgeErcToErcPOSDAO is HomeBridgeErcToErc {
         uint256[] _homeFeeForeignFeeArray, // [ 0 = _homeFee, 1 = _foreignFee ]
         address _blockReward,
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _rewardableInitialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -21,7 +21,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
         address _owner,
         uint256 _decimalShift,
         address _bridgeOnOtherSide
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
         require(_requiredBlockConfirmations != 0);

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -56,7 +56,7 @@ contract HomeBridgeErcToNative is
         uint256[] _foreignDailyLimitForeignMaxPerTxArray, // [ 0 = _foreignDailyLimit, 1 = _foreignMaxPerTx ]
         address _owner,
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,
@@ -83,7 +83,7 @@ contract HomeBridgeErcToNative is
         address _feeManager,
         uint256[] _homeFeeForeignFeeArray, // [ 0 = _homeFee, 1 = _foreignFee ]
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -21,7 +21,7 @@ contract ForeignBridgeNativeToErc is
         address _owner,
         uint256 _decimalShift,
         address _bridgeOnOtherSide
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _erc677token,
@@ -49,7 +49,7 @@ contract ForeignBridgeNativeToErc is
         uint256 _homeFee,
         uint256 _decimalShift,
         address _bridgeOnOtherSide
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _erc677token,

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -37,7 +37,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         uint256[] _foreignDailyLimitForeignMaxPerTxArray, // [ 0 = _foreignDailyLimit, 1 = _foreignMaxPerTx ]
         address _owner,
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,
@@ -61,7 +61,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         address _feeManager,
         uint256[] _homeFeeForeignFeeArray, // [ 0 = _homeFee, 1 = _foreignFee ]
         uint256 _decimalShift
-    ) external returns (bool) {
+    ) external onlyRelevantSender returns (bool) {
         _initialize(
             _validatorContract,
             _dailyLimitMaxPerTxMinPerTxArray,

--- a/test/rewardable_validators_test.js
+++ b/test/rewardable_validators_test.js
@@ -206,7 +206,9 @@ contract('RewardableValidators', async accounts => {
 
   describe('#upgradable', async () => {
     it('can be upgraded via upgradeToAndCall', async () => {
-      const storageProxy = await EternalStorageProxy.new().should.be.fulfilled
+      const storageProxy = await EternalStorageProxy.new({
+        from: accounts[0]
+      }).should.be.fulfilled
       const requiredSignatures = '2'
       const validators = [accounts[0], accounts[1]]
       const rewards = accounts.slice(3, 5)
@@ -214,7 +216,14 @@ contract('RewardableValidators', async accounts => {
       const data = bridgeValidators.contract.methods
         .initialize(requiredSignatures, validators, rewards, owner)
         .encodeABI()
-      await storageProxy.upgradeToAndCall('1', bridgeValidators.address, data).should.be.fulfilled
+      await storageProxy
+        .upgradeToAndCall('1', bridgeValidators.address, data, {
+          from: accounts[1]
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+      await storageProxy.upgradeToAndCall('1', bridgeValidators.address, data, {
+        from: accounts[0]
+      }).should.be.fulfilled
       const finalContract = await BridgeValidators.at(storageProxy.address)
       true.should.be.equal(await finalContract.isInitialized())
       expect(await finalContract.requiredSignatures()).to.be.bignumber.equal(requiredSignatures)
@@ -262,11 +271,14 @@ contract('RewardableValidators', async accounts => {
     accounts.slice(0, 5).forEach(validator => {
       it(`should remove ${validator} - with Proxy`, async () => {
         // Given
-        const proxy = await EternalStorageProxy.new()
+        const proxy = await EternalStorageProxy.new({ from: owner })
         const bridgeValidatorsImpl = await BridgeValidators.new()
         await proxy.upgradeTo('1', bridgeValidatorsImpl.address)
         bridgeValidators = await BridgeValidators.at(proxy.address)
         const { initialize, isInitialized, removeValidator } = bridgeValidators
+        await initialize(1, accounts.slice(0, 5), accounts.slice(5, 10), owner, {
+          from: accounts[1]
+        }).should.be.rejectedWith(ERROR_MSG)
         await initialize(1, accounts.slice(0, 5), accounts.slice(5, 10), owner, { from: owner }).should.be.fulfilled
         true.should.be.equal(await isInitialized())
 

--- a/test/validators_test.js
+++ b/test/validators_test.js
@@ -164,12 +164,21 @@ contract('BridgeValidators', async accounts => {
 
   describe('#upgradable', async () => {
     it('can be upgraded via upgradeToAndCall', async () => {
-      const storageProxy = await EternalStorageProxy.new().should.be.fulfilled
+      const storageProxy = await EternalStorageProxy.new({
+        from: accounts[0]
+      }).should.be.fulfilled
       const requiredSignatures = '2'
       const validators = [accounts[0], accounts[1]]
       const owner = accounts[2]
       const data = bridgeValidators.contract.methods.initialize(requiredSignatures, validators, owner).encodeABI()
-      await storageProxy.upgradeToAndCall('1', bridgeValidators.address, data).should.be.fulfilled
+      await storageProxy
+        .upgradeToAndCall('1', bridgeValidators.address, data, {
+          from: accounts[1]
+        })
+        .should.be.rejectedWith(ERROR_MSG)
+      await storageProxy.upgradeToAndCall('1', bridgeValidators.address, data, {
+        from: accounts[0]
+      }).should.be.fulfilled
       const finalContract = await BridgeValidators.at(storageProxy.address)
       true.should.be.equal(await finalContract.isInitialized())
       expect(await finalContract.requiredSignatures()).to.be.bignumber.equal(requiredSignatures)
@@ -217,11 +226,14 @@ contract('BridgeValidators', async accounts => {
     accounts.slice(0, 5).forEach(validator => {
       it(`should remove ${validator} - with Proxy`, async () => {
         // Given
-        const proxy = await EternalStorageProxy.new()
+        const proxy = await EternalStorageProxy.new({
+          from: owner
+        })
         const bridgeValidatorsImpl = await BridgeValidators.new()
         await proxy.upgradeTo('1', bridgeValidatorsImpl.address)
         bridgeValidators = await BridgeValidators.at(proxy.address)
         const { initialize, isInitialized, removeValidator } = bridgeValidators
+        await initialize(1, accounts.slice(0, 5), owner, { from: accounts[1] }).should.be.rejectedWith(ERROR_MSG)
         await initialize(1, accounts.slice(0, 5), owner, { from: owner }).should.be.fulfilled
         true.should.be.equal(await isInitialized())
 


### PR DESCRIPTION
Closes #323 

Contracts for `EternalStorageProxy` and `ClassicEternalStorageProxy` initialise owner in storage to `msg.sender`.

Added modifier then works as follows:
- If contract is called directly, without proxy, so that owner is not set initially, it allows to call `initialize()` without any restrictions.
- When proxy is used, owner in `EternalStorage` is set initially to contract deployer, so only current owner is allowed to call `initialize()`.
- When proxy implementation is updated through `updateAndCall()`, ownership is checked in `onlyUpgradeabilityOwner` modifier, so that only proxy owner will be able to perform upgrade.