### PR TITLE
Max signatures limit

### DIFF
--- a/contracts/libraries/Message.sol
+++ b/contracts/libraries/Message.sol
@@ -129,9 +129,9 @@ library Message {
     ) internal view {
         require(isAMBMessage || (!isAMBMessage && isMessageValid(_message)));
         uint256 requiredSignatures = _validatorContract.requiredSignatures();
-        uint8 amount;
+        uint256 amount;
         assembly {
-            amount := mload(add(_signatures, 1))
+            amount := and(mload(add(_signatures, 1)), 0xff)
         }
         require(amount >= requiredSignatures);
         bytes32 hash = hashMessage(_message, isAMBMessage);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,7 +56,7 @@ if [ "$SOLIDITY_COVERAGE" != true ]; then
 fi
 
 if [ "$SOLIDITY_COVERAGE" = true ]; then
-  node_modules/.bin/truffle test; istanbul report lcov
+  node --max-old-space-size=4096 node_modules/.bin/truffle test; istanbul report lcov
 
   if [ "$CONTINUOUS_INTEGRATION" = true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls

--- a/test/erc_to_erc/foreign_bridge.test.js
+++ b/test/erc_to_erc/foreign_bridge.test.js
@@ -7,7 +7,15 @@ const ERC677BridgeToken = artifacts.require('ERC677BridgeToken.sol')
 
 const { expect } = require('chai')
 const { ERROR_MSG, ZERO_ADDRESS, toBN } = require('../setup')
-const { createMessage, sign, signatureToVRS, ether, getEvents, expectEventInLogs } = require('../helpers/helpers')
+const {
+  createMessage,
+  sign,
+  signatureToVRS,
+  ether,
+  getEvents,
+  expectEventInLogs,
+  createFullAccounts
+} = require('../helpers/helpers')
 
 const oneEther = ether('1')
 const halfEther = ether('0.5')
@@ -19,6 +27,9 @@ const maxPerTx = halfEther
 const minPerTx = ether('0.01')
 const dailyLimit = oneEther
 const ZERO = toBN(0)
+const MAX_VALIDATORS = 50
+const MAX_SIGNATURES = MAX_VALIDATORS
+const MAX_GAS = 8000000
 const decimalShiftZero = 0
 
 contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
@@ -416,6 +427,48 @@ contract('ForeignBridge_ERC20_to_ERC20', async accounts => {
       logs[0].args.recipient.should.be.equal(recipient)
       logs[0].args.value.should.be.bignumber.equal(value)
       true.should.be.equal(await foreignBridgeWithThreeSigs.relayedMessages(txHash))
+    })
+
+    it('works with max allowed number of signatures required', async () => {
+      const recipient = accounts[8]
+      const value = halfEther
+      const validatorContract = await BridgeValidators.new()
+      const authorities = createFullAccounts(web3, MAX_VALIDATORS)
+      const addresses = authorities.map(account => account.address)
+      const ownerOfValidators = accounts[0]
+
+      await validatorContract.initialize(MAX_SIGNATURES, addresses, ownerOfValidators)
+      const erc20Token = await ERC677BridgeToken.new('Some ERC20', 'RSZT', 18)
+      const foreignBridgeWithMaxSigs = await ForeignBridge.new()
+
+      await foreignBridgeWithMaxSigs.initialize(
+        validatorContract.address,
+        erc20Token.address,
+        requireBlockConfirmations,
+        gasPrice,
+        [dailyLimit, maxPerTx, minPerTx],
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero
+      )
+      await erc20Token.mint(foreignBridgeWithMaxSigs.address, value)
+
+      const txHash = '0x35d3818e50234655f6aebb2a1cfbf30f59568d8a4ec72066fac5a25dbe7b8121'
+      const message = createMessage(recipient, value, txHash, foreignBridgeWithMaxSigs.address)
+
+      const vrsList = []
+      for (let i = 0; i < MAX_SIGNATURES; i++) {
+        const { signature } = await authorities[i].sign(message)
+        vrsList[i] = signatureToVRS(signature)
+      }
+
+      const { receipt } = await foreignBridgeWithMaxSigs.executeSignatures(
+        vrsList.map(vrs => vrs.v),
+        vrsList.map(vrs => vrs.r),
+        vrsList.map(vrs => vrs.s),
+        message
+      ).should.be.fulfilled
+      expect(receipt.gasUsed).to.be.lte(MAX_GAS)
     })
   })
   describe('#upgradeable', async () => {

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -198,6 +198,16 @@ function createAccounts(web3, amount) {
 
 module.exports.createAccounts = createAccounts
 
+function createFullAccounts(web3, amount) {
+  const array = []
+  for (let i = 0; i < amount; i++) {
+    array[i] = web3.eth.accounts.create()
+  }
+  return array
+}
+
+module.exports.createFullAccounts = createFullAccounts
+
 function addTxHashToAMBData(encodedData, transactionHash) {
   return encodedData.slice(0, 2) + strip0x(transactionHash) + encodedData.slice(2)
 }

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -17,7 +17,8 @@ const {
   getEvents,
   ether,
   expectEventInLogs,
-  createAccounts
+  createAccounts,
+  createFullAccounts
 } = require('../helpers/helpers')
 
 const oneEther = ether('1')
@@ -30,6 +31,7 @@ const homeMaxPerTx = halfEther
 const ZERO = toBN(0)
 const MAX_GAS = 8000000
 const MAX_VALIDATORS = 50
+const MAX_SIGNATURES = MAX_VALIDATORS
 const decimalShiftZero = 0
 
 contract('ForeignBridge', async accounts => {
@@ -431,6 +433,48 @@ contract('ForeignBridge', async accounts => {
       logs[0].args.recipient.should.be.equal(recipient)
       logs[0].args.value.should.be.bignumber.equal(value)
       true.should.be.equal(await foreignBridgeWithThreeSigs.relayedMessages(txHash))
+    })
+    it('works with max allowed number of signatures required', async () => {
+      const recipient = accounts[8]
+      const value = halfEther
+      const validatorContract = await BridgeValidators.new()
+      const authorities = createFullAccounts(web3, MAX_VALIDATORS)
+      const addresses = authorities.map(account => account.address)
+      const ownerOfValidators = accounts[0]
+
+      await validatorContract.initialize(MAX_SIGNATURES, addresses, ownerOfValidators)
+      const erc20Token = await POA20.new('Some ERC20', 'RSZT', 18)
+      const foreignBridgeWithMaxSigs = await ForeignBridge.new()
+
+      await foreignBridgeWithMaxSigs.initialize(
+        validatorContract.address,
+        erc20Token.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        decimalShiftZero,
+        otherSideBridgeAddress
+      )
+      await erc20Token.transferOwnership(foreignBridgeWithMaxSigs.address)
+
+      const txHash = '0x35d3818e50234655f6aebb2a1cfbf30f59568d8a4ec72066fac5a25dbe7b8121'
+      const message = createMessage(recipient, value, txHash, foreignBridgeWithMaxSigs.address)
+
+      const vrsList = []
+      for (let i = 0; i < MAX_SIGNATURES; i++) {
+        const { signature } = await authorities[i].sign(message)
+        vrsList[i] = signatureToVRS(signature)
+      }
+
+      const { receipt } = await foreignBridgeWithMaxSigs.executeSignatures(
+        vrsList.map(vrs => vrs.v),
+        vrsList.map(vrs => vrs.r),
+        vrsList.map(vrs => vrs.s),
+        message
+      ).should.be.fulfilled
+      expect(receipt.gasUsed).to.be.lte(MAX_GAS)
     })
     it('Should fail if length of signatures is not equal', async () => {
       const recipient = accounts[8]


### PR DESCRIPTION
Closes #327 

- Fixed bug, related to `uint8` truncation in `Message.sol` library.
- Added tests for covering maximum possible required signatures. 