### PR TITLE
Simplified require conditions for AMB bridge

### DIFF
--- a/contracts/libraries/Message.sol
+++ b/contracts/libraries/Message.sol
@@ -104,7 +104,7 @@ library Message {
         IBridgeValidators _validatorContract,
         bool isAMBMessage
     ) internal view {
-        require(isAMBMessage || (!isAMBMessage && isMessageValid(_message)));
+        require(isAMBMessage || isMessageValid(_message));
         uint256 requiredSignatures = _validatorContract.requiredSignatures();
         // It is not necessary to check that arrays have the same length since it will be handled
         // during attempt to access to the corresponding elements in the loop and the call will be reverted.
@@ -127,7 +127,7 @@ library Message {
         IBridgeValidators _validatorContract,
         bool isAMBMessage
     ) internal view {
-        require(isAMBMessage || (!isAMBMessage && isMessageValid(_message)));
+        require(isAMBMessage || isMessageValid(_message));
         uint256 requiredSignatures = _validatorContract.requiredSignatures();
         uint256 amount;
         assembly {

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
@@ -13,7 +13,7 @@ contract BasicAMB is BasicBridge {
         address _owner
     ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
-        require(_validatorContract != address(0) && AddressUtils.isContract(_validatorContract));
+        require(AddressUtils.isContract(_validatorContract));
         require(_gasPrice > 0);
         require(_requiredBlockConfirmations > 0);
 


### PR DESCRIPTION
It seems to me, that some of the `requires` for AMB bridge can be simplified, doing so may save some gas during execution.