### PR TITLE
Fixes in AMB deployment related documentation and scripts 

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -469,8 +469,10 @@ BRIDGE_MODE=ARBITRARY_MESSAGE
 # deployments and initial configuration. The account's balance must contain
 # funds from both networks.
 DEPLOYMENT_ACCOUNT_PRIVATE_KEY=67..14
-# The "gas" parameter set in every deployment/configuration transaction.
-DEPLOYMENT_GAS_LIMIT=5000000
+# Extra gas added to the estimated gas of a particular deployment/configuration transaction
+# E.g. if estimated gas returns 100000 and the parameter is 0.2,
+# the transaction gas limit will be (100000 + 100000 * 0.2) = 120000
+DEPLOYMENT_GAS_LIMIT_EXTRA=0.2
 # The "gasPrice" parameter set in every deployment/configuration transaction on
 # Home network (in Wei).
 HOME_DEPLOYMENT_GAS_PRICE=10000000000
@@ -484,17 +486,16 @@ GET_RECEIPT_INTERVAL_IN_MILLISECONDS=3000
 # The RPC channel to a Home node able to handle deployment/configuration
 # transactions.
 HOME_RPC_URL=https://poa.infura.io
-# The address of an administrator on the Home network who can change bridge
-# parameters and a validator's contract. For extra security we recommended using
-# a multi-sig wallet contract address here.
-HOME_OWNER_MULTISIG=0x
-# The address from which a validator's contract can be upgraded on Home.
-HOME_UPGRADEABLE_ADMIN_VALIDATORS=0x
-# The address from which the bridge's contract can be upgraded on Home.
-HOME_UPGRADEABLE_ADMIN_BRIDGE=0x
-
-# The maximum value of estimated gas for one transaction in Wei.
-HOME_MAX_AMOUNT_PER_TX=1500000000000000000000000
+# Address on Home network with permissions to change parameters of the bridge contract.
+# For extra security we recommended using a multi-sig wallet contract address here.
+HOME_BRIDGE_OWNER=0x
+# Address on Home network with permissions to change parameters of bridge validator contract.
+HOME_VALIDATORS_OWNER=0x
+# Address on Home network with permissions to upgrade the bridge contract and the
+# bridge validator contract.
+HOME_UPGRADEABLE_ADMIN=0x
+# The maximum value of gas for one call to be allowed for relaying.
+HOME_MAX_AMOUNT_PER_TX=20000000
 # The finalization threshold. The number of blocks issued after the block with
 # the corresponding deposit transaction to guarantee the transaction will not be
 # rolled back.
@@ -507,16 +508,16 @@ HOME_GAS_PRICE=1000000000
 # The RPC channel to a Foreign node able to handle deployment/configuration
 # transactions.
 FOREIGN_RPC_URL=https://mainnet.infura.io
-# The address of an administrator on the Foreign network who can change bridge
-# parameters and the validator's contract. For extra security we recommended
-# using a multi-sig wallet contract address here.
-FOREIGN_OWNER_MULTISIG=0x
-# The address from which a validator's contract can be upgraded on Foreign.
-FOREIGN_UPGRADEABLE_ADMIN_VALIDATORS=0x
-# The address from which the bridge's contract can be upgraded on Foreign.
-FOREIGN_UPGRADEABLE_ADMIN_BRIDGE=0x
-# The maximum value of estimated gas for one transaction in Wei.
-FOREIGN_MAX_AMOUNT_PER_TX=1500000000000000000000000
+# Address on Foreign network with permissions to change parameters of the bridge contract.
+# For extra security we recommended using a multi-sig wallet contract address here.
+FOREIGN_BRIDGE_OWNER=0x
+# Address on Foreign network with permissions to change parameters of bridge validator contract.
+FOREIGN_VALIDATORS_OWNER=0x
+# Address on Foreign network with permissions to upgrade the bridge contract and the
+# bridge validator contract.
+FOREIGN_UPGRADEABLE_ADMIN=0x
+# The maximum value of gas for one call to be allowed for relaying.
+FOREIGN_MAX_AMOUNT_PER_TX=20000000
 # The finalization threshold. The number of blocks issued after the block with
 # the corresponding deposit transaction to guarantee the transaction will not be
 # rolled back.
@@ -534,7 +535,7 @@ REQUIRED_NUMBER_OF_VALIDATORS=1
 # addresses are collected on the Home side. The same addresses will be used on
 # the Foreign network to confirm that the finalized agreement was transferred
 # correctly to the Foreign network.
-VALIDATORS="0x 0x 0x"
+VALIDATORS=0x 0x 0x
 
 # The api url of an explorer to verify all the deployed contracts in Home network. Supported explorers: Blockscout, etherscan
 #HOME_EXPLORER_URL=https://blockscout.com/poa/core/api

--- a/deploy/src/arbitrary_message/foreign.js
+++ b/deploy/src/arbitrary_message/foreign.js
@@ -36,10 +36,8 @@ async function initializeBridge({ validatorsBridge, bridge, initialNonce }) {
   let nonce = initialNonce
 
   console.log(`Foreign Validators: ${validatorsBridge.options.address},
-  FOREIGN_MAX_AMOUNT_PER_TX: ${FOREIGN_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(
-    FOREIGN_MAX_AMOUNT_PER_TX
-  )} in eth,
-    HOME_GAS_PRICE: ${FOREIGN_GAS_PRICE}, HOME_REQUIRED_BLOCK_CONFIRMATIONS : ${FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS}
+  FOREIGN_MAX_AMOUNT_PER_TX (gas limit per call): ${FOREIGN_MAX_AMOUNT_PER_TX},
+  FOREIGN_GAS_PRICE: ${FOREIGN_GAS_PRICE}, FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS : ${FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS}
   `)
   const initializeFBridgeData = await bridge.methods
     .initialize(
@@ -69,7 +67,7 @@ async function initializeBridge({ validatorsBridge, bridge, initialNonce }) {
 
 async function deployForeign() {
   console.log('========================================')
-  console.log('deploying ForeignBridge')
+  console.log('Deploying Arbitrary Message Bridge at Foreign')
   console.log('========================================\n')
 
   let nonce = await web3Foreign.eth.getTransactionCount(DEPLOYMENT_ACCOUNT_ADDRESS)
@@ -125,25 +123,25 @@ async function deployForeign() {
   })
   nonce++
 
-  console.log('\ndeploying foreignBridge storage\n')
+  console.log('\ndeploying ForeignAMBridge storage\n')
   const foreignBridgeStorage = await deployContract(EternalStorageProxy, [], {
     from: DEPLOYMENT_ACCOUNT_ADDRESS,
     network: 'foreign',
     nonce
   })
   nonce++
-  console.log('[Foreign] ForeignBridge Storage: ', foreignBridgeStorage.options.address)
+  console.log('[Foreign] ForeignAMBridge Storage: ', foreignBridgeStorage.options.address)
 
-  console.log('\ndeploying foreignBridge implementation\n')
+  console.log('\ndeploying ForeignAMBridge implementation\n')
   const foreignBridgeImplementation = await deployContract(ForeignBridge, [], {
     from: DEPLOYMENT_ACCOUNT_ADDRESS,
     network: 'foreign',
     nonce
   })
   nonce++
-  console.log('[Foreign] ForeignBridge Implementation: ', foreignBridgeImplementation.options.address)
+  console.log('[Foreign] ForeignAMBridge Implementation: ', foreignBridgeImplementation.options.address)
 
-  console.log('\nhooking up ForeignBridge storage to ForeignBridge implementation')
+  console.log('\nhooking up ForeignAMBridge storage to ForeignAMBridge implementation')
   await upgradeProxy({
     proxy: foreignBridgeStorage,
     implementationAddress: foreignBridgeImplementation.options.address,
@@ -169,7 +167,7 @@ async function deployForeign() {
     url: FOREIGN_RPC_URL
   })
 
-  console.log('\nForeign Deployment Bridge completed\n')
+  console.log('\nDeployment of Arbitrary Message Bridge at Foreign completed\n')
 
   return {
     foreignBridge: {

--- a/deploy/src/arbitrary_message/home.js
+++ b/deploy/src/arbitrary_message/home.js
@@ -36,7 +36,7 @@ async function initializeBridge({ validatorsBridge, bridge, initialNonce }) {
   let nonce = initialNonce
   console.log('\ninitializing Home Bridge with following parameters:\n')
   console.log(`Home Validators: ${validatorsBridge.options.address},
-  HOME_MAX_AMOUNT_PER_TX: ${HOME_MAX_AMOUNT_PER_TX} which is ${Web3Utils.fromWei(HOME_MAX_AMOUNT_PER_TX)} in eth,
+  HOME_MAX_AMOUNT_PER_TX (gas limit per call): ${HOME_MAX_AMOUNT_PER_TX},
   HOME_GAS_PRICE: ${HOME_GAS_PRICE}, HOME_REQUIRED_BLOCK_CONFIRMATIONS : ${HOME_REQUIRED_BLOCK_CONFIRMATIONS}
   `)
   const initializeHomeBridgeData = await bridge.methods
@@ -67,7 +67,7 @@ async function initializeBridge({ validatorsBridge, bridge, initialNonce }) {
 
 async function deployHome() {
   console.log('========================================')
-  console.log('Deploying HomeBridge')
+  console.log('Deploying Arbitrary Message Bridge at Home')
   console.log('========================================\n')
 
   let nonce = await web3Home.eth.getTransactionCount(DEPLOYMENT_ACCOUNT_ADDRESS)
@@ -121,23 +121,23 @@ async function deployHome() {
   })
   nonce++
 
-  console.log('\ndeploying homeBridge storage\n')
+  console.log('\ndeploying HomeAMBridge storage\n')
   const homeBridgeStorage = await deployContract(EternalStorageProxy, [], {
     from: DEPLOYMENT_ACCOUNT_ADDRESS,
     nonce
   })
   nonce++
-  console.log('[Home] HomeBridge Storage: ', homeBridgeStorage.options.address)
+  console.log('[Home] HomeAMBridge Storage: ', homeBridgeStorage.options.address)
 
-  console.log('\ndeploying homeBridge implementation\n')
+  console.log('\ndeploying HomeAMBridge implementation\n')
   const homeBridgeImplementation = await deployContract(HomeBridge, [], {
     from: DEPLOYMENT_ACCOUNT_ADDRESS,
     nonce
   })
   nonce++
-  console.log('[Home] HomeBridge Implementation: ', homeBridgeImplementation.options.address)
+  console.log('[Home] HomeAMBridge Implementation: ', homeBridgeImplementation.options.address)
 
-  console.log('\nhooking up HomeBridge storage to HomeBridge implementation')
+  console.log('\nhooking up HomeAMBridge storage to HomeAMBridge implementation')
   await upgradeProxy({
     proxy: homeBridgeStorage,
     implementationAddress: homeBridgeImplementation.options.address,
@@ -162,7 +162,7 @@ async function deployHome() {
     url: HOME_RPC_URL
   })
 
-  console.log('\nHome Deployment Bridge completed\n')
+  console.log('\nDeployment of Arbitrary Message Bridge at Home completed\n')
   return {
     homeBridge: {
       address: homeBridgeStorage.options.address,

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -126,7 +126,7 @@ if (BRIDGE_MODE === 'AMB_ERC_TO_ERC') {
     BRIDGEABLE_TOKEN_DECIMALS: envalid.num(),
     FOREIGN_MIN_AMOUNT_PER_TX: bigNumValidator(),
     FOREIGN_DAILY_LIMIT: bigNumValidator(),
-    DEPLOY_REWARDABLE_TOKEN: envalid.bool()
+    DEPLOY_REWARDABLE_TOKEN: envalid.bool({default: false})
   }
 
   if (DEPLOY_REWARDABLE_TOKEN === 'true') {
@@ -202,7 +202,7 @@ if (BRIDGE_MODE === 'NATIVE_TO_ERC') {
     BRIDGEABLE_TOKEN_SYMBOL: envalid.str(),
     BRIDGEABLE_TOKEN_DECIMALS: envalid.num(),
     FOREIGN_MIN_AMOUNT_PER_TX: bigNumValidator(),
-    DEPLOY_REWARDABLE_TOKEN: envalid.bool()
+    DEPLOY_REWARDABLE_TOKEN: envalid.bool({default: false})
   }
 
   if (DEPLOY_REWARDABLE_TOKEN === 'true') {
@@ -221,8 +221,8 @@ if (BRIDGE_MODE === 'ERC_TO_ERC') {
     BRIDGEABLE_TOKEN_NAME: envalid.str(),
     BRIDGEABLE_TOKEN_SYMBOL: envalid.str(),
     BRIDGEABLE_TOKEN_DECIMALS: envalid.num(),
-    DEPLOY_REWARDABLE_TOKEN: envalid.bool(),
-    ERC20_EXTENDED_BY_ERC677: envalid.bool(),
+    DEPLOY_REWARDABLE_TOKEN: envalid.bool({default: false}),
+    ERC20_EXTENDED_BY_ERC677: envalid.bool({default: false}),
     FOREIGN_MIN_AMOUNT_PER_TX: bigNumValidator()
   }
 


### PR DESCRIPTION
As part of the AMB deployment to the real chains it was found that deployment scripts produce inaccurate and ambiguous output. 

Also it was found that the example of configuration `.env` file contains obsoleted parameters.

Finally, the module checking correctness of configuration parameters was changed to not require setup of `DEPLOY_REWARDABLE_TOKEN` parameter.