### PR TITLE
Restriction on claiming Chai token

### DIFF
--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -65,6 +65,8 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
 
     function claimTokens(address _token, address _to) public {
         require(_token != address(erc20token()));
+        // Chai token is not claimable if investing into Chai is enabled
+        require(_token != address(chaiToken()) || !isChaiTokenEnabled());
         if (_token == address(halfDuplexErc20token())) {
             // SCD is not claimable if the bridge accepts deposits of this token
             // solhint-disable-next-line not-rely-on-time


### PR DESCRIPTION
It was found that the pervious version of contracts allowed to claim chai tokens. This is considered to be insecure.
Fixed that by adding one more validation in `claimTokens` function of `ForeignBridgeErcToNative`.
