### PR TITLE
Rename BlockReward functions

### DIFF
--- a/contracts/interfaces/IBlockReward.sol
+++ b/contracts/interfaces/IBlockReward.sol
@@ -5,7 +5,7 @@ interface IBlockReward {
     function mintedTotally() external view returns (uint256);
     function mintedTotallyByBridge(address _bridge) external view returns (uint256);
     function bridgesAllowedLength() external view returns (uint256);
-    function addBridgeTokenFeeReceivers(uint256 _amount) external;
-    function addBridgeNativeFeeReceivers(uint256 _amount) external;
+    function addBridgeTokenRewardReceivers(uint256 _amount) external;
+    function addBridgeNativeRewardReceivers(uint256 _amount) external;
     function blockRewardContractId() external pure returns (bytes4);
 }

--- a/contracts/mocks/BlockReward.sol
+++ b/contracts/mocks/BlockReward.sol
@@ -48,7 +48,7 @@ contract BlockReward {
         token = _token;
     }
 
-    function addBridgeNativeFeeReceivers(uint256 _amount) external {
+    function addBridgeNativeRewardReceivers(uint256 _amount) external {
         feeAmount = _amount;
         uint256 feePerValidator = _amount.div(validatorList.length);
 
@@ -67,7 +67,7 @@ contract BlockReward {
         }
     }
 
-    function addBridgeTokenFeeReceivers(uint256 _amount) external {
+    function addBridgeTokenRewardReceivers(uint256 _amount) external {
         validatorRewardList = new uint256[](validatorList.length);
         feeAmount = _amount;
         uint256 feePerValidator = _amount.div(validatorList.length);

--- a/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/FeeManagerErcToErcPOSDAO.sol
@@ -17,6 +17,6 @@ contract FeeManagerErcToErcPOSDAO is BlockRewardFeeManager {
 
     function distributeFeeFromBlockReward(uint256 _fee) internal {
         IBlockReward blockReward = _blockRewardContract();
-        blockReward.addBridgeTokenFeeReceivers(_fee);
+        blockReward.addBridgeTokenRewardReceivers(_fee);
     }
 }

--- a/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/FeeManagerErcToNativePOSDAO.sol
@@ -10,7 +10,7 @@ contract FeeManagerErcToNativePOSDAO is BlockRewardFeeManager {
 
     function distributeFeeFromBlockReward(uint256 _fee) internal {
         IBlockReward blockReward = _blockRewardContract();
-        blockReward.addBridgeNativeFeeReceivers(_fee);
+        blockReward.addBridgeNativeRewardReceivers(_fee);
     }
 
     function getAmountToBurn(uint256 _value) public view returns (uint256) {


### PR DESCRIPTION
Renames `BlockReward.addBridgeTokenFeeReceivers` to `addBridgeTokenRewardReceivers` and `addBridgeNativeFeeReceivers` to `addBridgeNativeRewardReceivers` according to the latest changes in POSDAO contracts: https://github.com/poanetwork/posdao-contracts/commit/97858990b7c985983d61d4e0c39fd6ac62a55e23

I decided to rename `Fee` to `Reward` because there can be a reward from the bridge which is not only fee - for example, the scheme https://www.staketoken.net/token-model/reward-mechanics/xdai-rewards assumes that the Interest may be distributed to stakers in xDai coins from the bridge (that could be done through the `BlockReward.addBridgeNativeRewardReceivers` function previously named `addBridgeNativeFeeReceivers`)