### PR TITLE
Update interest receiver

### DIFF
--- a/contracts/mocks/InterestReceiverMock.sol
+++ b/contracts/mocks/InterestReceiverMock.sol
@@ -6,6 +6,9 @@ contract InterestReceiverMock is InterestReceiver {
     address private chaiTokenMock;
     address private daiTokenMock;
 
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address _owner) public InterestReceiver(_owner) {}
+
     function setChaiToken(IChai _chaiToken) external {
         chaiTokenMock = _chaiToken;
         daiTokenMock = _chaiToken.daiToken();

--- a/contracts/mocks/InterestReceiverMock.sol
+++ b/contracts/mocks/InterestReceiverMock.sol
@@ -3,19 +3,19 @@ pragma solidity 0.4.24;
 import "../upgradeable_contracts/InterestReceiver.sol";
 
 contract InterestReceiverMock is InterestReceiver {
-    bytes32 internal constant CHAI_TOKEN_MOCK = 0x5d6f4e61a116947624416975e8d26d4aff8f32e21ea6308dfa35cee98ed41fd8; // keccak256(abi.encodePacked("chaiTokenMock"))
-    bytes32 internal constant DAI_TOKEN_MOCK = 0xbadb505d38473a045eb3ce02f80bb0c4b30c429923cd667bca7f33083bad4e14; // keccak256(abi.encodePacked("daiTokenMock"))
+    address private chaiTokenMock;
+    address private daiTokenMock;
 
     function setChaiToken(IChai _chaiToken) external {
-        addressStorage[CHAI_TOKEN_MOCK] = _chaiToken;
-        addressStorage[DAI_TOKEN_MOCK] = _chaiToken.daiToken();
+        chaiTokenMock = _chaiToken;
+        daiTokenMock = _chaiToken.daiToken();
     }
 
     function chaiToken() public view returns (IChai) {
-        return IChai(addressStorage[CHAI_TOKEN_MOCK]);
+        return IChai(chaiTokenMock);
     }
 
     function daiToken() public view returns (ERC20) {
-        return ERC20(addressStorage[DAI_TOKEN_MOCK]);
+        return ERC20(daiTokenMock);
     }
 }

--- a/contracts/mocks/InterestReceiverMock.sol
+++ b/contracts/mocks/InterestReceiverMock.sol
@@ -6,8 +6,12 @@ contract InterestReceiverMock is InterestReceiver {
     address private chaiTokenMock;
     address private daiTokenMock;
 
-    // solhint-disable-next-line no-empty-blocks
-    constructor(address _owner) public InterestReceiver(_owner) {}
+    // solhint-disable no-empty-blocks
+    constructor(address _owner, address _bridge, address _xDaiReceiver)
+        public
+        InterestReceiver(_owner, _bridge, _xDaiReceiver)
+    {}
+    // solhint-enable no-empty-blocks
 
     function setChaiToken(IChai _chaiToken) external {
         chaiTokenMock = _chaiToken;

--- a/contracts/upgradeable_contracts/InterestReceiver.sol
+++ b/contracts/upgradeable_contracts/InterestReceiver.sol
@@ -1,10 +1,9 @@
 pragma solidity 0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "../interfaces/IChai.sol";
 import "../interfaces/ERC677Receiver.sol";
-import "./Initializable.sol";
-import "./Ownable.sol";
 import "./Claimable.sol";
 import "./TokenSwapper.sol";
 
@@ -12,15 +11,13 @@ import "./TokenSwapper.sol";
 * @title InterestReceiver
 * @dev Example contract for receiving Chai interest and immediatly converting it into Dai
 */
-contract InterestReceiver is ERC677Receiver, Initializable, Ownable, Claimable, TokenSwapper {
+contract InterestReceiver is ERC677Receiver, Ownable, Claimable, TokenSwapper {
     /**
     * @dev Initializes interest receiver, sets an owner of a contract
     * @param _owner address of owner account, only owner can withdraw Dai tokens from contract
     */
-    function initialize(address _owner) external onlyRelevantSender {
-        require(!isInitialized());
-        setOwner(_owner);
-        setInitialize();
+    constructor(address _owner) public {
+        _transferOwnership(_owner);
     }
 
     /**
@@ -42,8 +39,6 @@ contract InterestReceiver is ERC677Receiver, Initializable, Ownable, Claimable, 
     * @param _value amount of transferred tokens
     */
     function onTokenTransfer(address, uint256 _value, bytes) external returns (bool) {
-        require(isInitialized());
-
         uint256 chaiBalance = chaiToken().balanceOf(address(this));
 
         require(_value <= chaiBalance);
@@ -66,8 +61,6 @@ contract InterestReceiver is ERC677Receiver, Initializable, Ownable, Claimable, 
     * @param _to address of tokens receiver
     */
     function withdraw(address _to) external onlyOwner {
-        require(isInitialized());
-
         daiToken().transfer(_to, daiToken().balanceOf(address(this)));
     }
 

--- a/contracts/upgradeable_contracts/InterestReceiver.sol
+++ b/contracts/upgradeable_contracts/InterestReceiver.sol
@@ -23,6 +23,7 @@ contract InterestReceiver is ERC677Receiver, Ownable, Claimable, TokenSwapper {
 
     /**
     * @dev Initializes interest receiver, sets an owner of a contract
+    * @param _owner address of owner account, only owner can withdraw Dai tokens from contract
     * @param _bridgeContract address of the bridge contract in the foreign chain
     * @param _receiverInXDai address of the receiver account, in the xDai chain
     */

--- a/deploy/src/utils/deployInterestReceiver.js
+++ b/deploy/src/utils/deployInterestReceiver.js
@@ -1,9 +1,7 @@
-const assert = require('assert')
-const Web3Utils = require('web3-utils')
 const env = require('../loadEnv')
 
-const { deployContract, privateKeyToAddress, sendRawTxForeign } = require('../deploymentUtils')
-const { web3Foreign, deploymentPrivateKey, FOREIGN_RPC_URL } = require('../web3')
+const { deployContract, privateKeyToAddress } = require('../deploymentUtils')
+const { web3Foreign } = require('../web3')
 
 const {
   foreignContracts: { InterestReceiver }
@@ -18,28 +16,14 @@ const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVAT
 
 async function deployInterestReceiver() {
   let foreignNonce = await web3Foreign.eth.getTransactionCount(DEPLOYMENT_ACCOUNT_ADDRESS)
-  console.log('\n[Foreign] deploying Interest receiver contract')
+  console.log('\n[Foreign] deploying Interest receiver contract, setting owner to ', FOREIGN_INTEREST_RECEIVER_OWNER)
   const interestReceiver = await deployContract(
     InterestReceiver,
-    [],
+    [FOREIGN_INTEREST_RECEIVER_OWNER],
     { from: DEPLOYMENT_ACCOUNT_ADDRESS, network: 'foreign', nonce: foreignNonce }
   )
   foreignNonce++
   console.log('[Foreign] Interest receiver: ', interestReceiver.options.address)
-
-  console.log('[Foreign] initializing contract owner to ', FOREIGN_INTEREST_RECEIVER_OWNER)
-  const initializeData = await interestReceiver.methods
-    .initialize(FOREIGN_INTEREST_RECEIVER_OWNER)
-    .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
-  const txInitialize = await sendRawTxForeign({
-    data: initializeData,
-    nonce: foreignNonce,
-    to: interestReceiver.options.address,
-    privateKey: deploymentPrivateKey,
-    url: FOREIGN_RPC_URL
-  })
-  assert.strictEqual(Web3Utils.hexToNumber(txInitialize.status), 1, 'Transaction Failed')
-
   console.log('\nInterest receiver deployment is completed\n')
   return {
     interestReceiverAddress: interestReceiver.options.address

--- a/test/erc_to_native/foreign_bridge.test.js
+++ b/test/erc_to_native/foreign_bridge.test.js
@@ -1622,8 +1622,7 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
         otherSideBridge.address
       )
       chaiToken = await createChaiToken(token, foreignBridge, owner)
-      interestRecipient = await InterestReceiverMock.new({ from: owner })
-      await interestRecipient.initialize(accounts[3], { from: owner })
+      interestRecipient = await InterestReceiverMock.new(accounts[3], { from: owner })
       await interestRecipient.setChaiToken(chaiToken.address)
       await token.transfer(ZERO_ADDRESS, await token.balanceOf(accounts[3]), { from: accounts[3] })
     })


### PR DESCRIPTION
This PR optimizes `InterestReceiver` for usage without `EternalStorage`, since it will be deployed without proxy contract. 
Continues #380 