### PR TITLE
Call prepareToPOSDAO as part of upgrade home bridge implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {

--- a/upgrade/src/upgradeBridgeOnHome.js
+++ b/upgrade/src/upgradeBridgeOnHome.js
@@ -15,6 +15,18 @@ const {
   NEW_IMPLEMENTATION_XDAI_BRIDGE
 } = process.env
 
+const migrationMethodAbi = [
+  {
+    constant: false,
+    inputs: [],
+    name: 'prepareToPOSDAO',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function'
+  }
+]
+
 const web3 = new Web3(new Web3.providers.HttpProvider(HOME_RPC_URL))
 const { address } = web3.eth.accounts.wallet.add(HOME_PRIVKEY)
 
@@ -26,7 +38,10 @@ const upgradeBridgeOnHome = async () => {
 
     await validatorState(web3, address, multiSigWallet)
 
-    const data = proxy.methods.upgradeTo('4', NEW_IMPLEMENTATION_XDAI_BRIDGE).encodeABI()
+    const bridge = new web3.eth.Contract(migrationMethodAbi, HOME_BRIDGE_ADDRESS)
+    const upgradeData = bridge.methods.prepareToPOSDAO().encodeABI()
+
+    const data = proxy.methods.upgradeToAndCall('4', NEW_IMPLEMENTATION_XDAI_BRIDGE, upgradeData).encodeABI()
 
     await callMultiSigWallet({
       role: ROLE,


### PR DESCRIPTION
New implementation of the bridge contract for the xDai chain: https://blockscout.com/poa/xdai/address/0x26077961Db25E38032eD3C30e5791444fa686D68/contracts

As soon as the proxy contract is updated with the reference to the new implementation, the `prepareToPOSDAO()` is called.

The previous implementation of the bridge contract: https://blockscout.com/poa/xdai/address/0xC7b4618d03a756f8345Bd1bF1cCCbe3681f823Ef/contracts