### PR TITLE
Bump version to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update project version related to changes in #404 

These changes breaks e2e on the oracle and monitor sides https://github.com/poanetwork/tokenbridge/issues/309 was created to reflect this new behaviour in the tests.

But the changes were tested on the xDai bridge. The address of new implementation is [0x83c2e0e3b5328e599a3cba95d97090fa7d0fde8b](https://etherscan.io/address/0x83c2e0e3b5328e599a3cba95d97090fa7d0fde8b).