### PR TITLE
Fix alternative receiver behaviour for amb-erc-to-erc

### DIFF
--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -71,9 +71,9 @@ contract BasicAMBErc677ToErc677 is
         return mediatorContractOnOtherSide();
     }
 
-    function passMessage(address _from, uint256 _value) internal {
+    function passMessage(address _from, address _receiver, uint256 _value) internal {
         bytes4 methodSelector = this.handleBridgedTokens.selector;
-        bytes memory data = abi.encodeWithSelector(methodSelector, _from, _value, nonce());
+        bytes memory data = abi.encodeWithSelector(methodSelector, _receiver, _value, nonce());
 
         bytes32 dataHash = keccak256(data);
         setMessageHashValue(dataHash, _value);
@@ -197,7 +197,7 @@ contract BasicAMBErc677ToErc677 is
         addressStorage[keccak256(abi.encodePacked("messageHashRecipient", _hash))] = _recipient;
     }
 
-    function messageHashRecipient(bytes32 _hash) internal view returns (address) {
+    function messageHashRecipient(bytes32 _hash) public view returns (address) {
         return addressStorage[keccak256(abi.encodePacked("messageHashRecipient", _hash))];
     }
 
@@ -249,7 +249,7 @@ contract BasicAMBErc677ToErc677 is
             setFixedAssets(txHash);
         }
         if (unlockOnForeign) {
-            passMessage(recipient, valueToUnlock);
+            passMessage(recipient, recipient, valueToUnlock);
         }
     }
 

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -197,7 +197,7 @@ contract BasicAMBErc677ToErc677 is
         addressStorage[keccak256(abi.encodePacked("messageHashRecipient", _hash))] = _recipient;
     }
 
-    function messageHashRecipient(bytes32 _hash) public view returns (address) {
+    function messageHashRecipient(bytes32 _hash) internal view returns (address) {
         return addressStorage[keccak256(abi.encodePacked("messageHashRecipient", _hash))];
     }
 

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
@@ -15,7 +15,7 @@ contract ForeignAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
         bytes _data
     ) internal {
         if (!lock()) {
-            passMessage(chooseReceiver(_from, _data), _value);
+            passMessage(_from, chooseReceiver(_from, _data), _value);
         }
     }
 

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignStakeTokenMediator.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignStakeTokenMediator.sol
@@ -27,7 +27,7 @@ contract ForeignStakeTokenMediator is BasicStakeTokenMediator {
         bytes _data
     ) internal {
         if (!lock()) {
-            passMessage(chooseReceiver(_from, _data), _value);
+            passMessage(_from, chooseReceiver(_from, _data), _value);
         }
     }
 
@@ -48,7 +48,7 @@ contract ForeignStakeTokenMediator is BasicStakeTokenMediator {
     function _transferWithOptionalMint(address _recipient, uint256 _value) internal {
         IBurnableMintableERC677Token token = IBurnableMintableERC677Token(erc677token());
         uint256 balance = token.balanceOf(address(this));
-        if (_recipient != address(0) && balance == 0) {
+        if (balance == 0) {
             token.mint(_recipient, _value);
         } else if (balance < _value) {
             token.mint(address(this), _value - balance);

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeAMBErc677ToErc677.sol
@@ -12,7 +12,7 @@ contract HomeAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
     function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value, bytes _data) internal {
         if (!lock()) {
             IBurnableMintableERC677Token(_token).burn(_value);
-            passMessage(chooseReceiver(_from, _data), _value);
+            passMessage(_from, chooseReceiver(_from, _data), _value);
         }
     }
 

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
@@ -136,11 +136,11 @@ contract HomeStakeTokenMediator is BasicStakeTokenMediator, HomeStakeTokenFeeMan
 
             if (address(_blockRewardContract()) == address(0)) {
                 // in case if block reward contract is not configured, the fee is not collected
-                passMessage(chooseReceiver(_from, _data), _value);
+                passMessage(_from, chooseReceiver(_from, _data), _value);
             } else {
                 // when block reward contract is defined, the calculated fee is subtracted from the original value
                 uint256 fee = calculateFee(_value);
-                passMessage(chooseReceiver(_from, _data), _value.sub(fee));
+                passMessage(_from, chooseReceiver(_from, _data), _value.sub(fee));
                 if (fee > 0) {
                     // the fee itself is distributed later in the block reward contract
                     _blockRewardContract().addBridgeTokenRewardReceivers(fee);

--- a/test/amb_erc677_to_erc677/foreign_bridge.test.js
+++ b/test/amb_erc677_to_erc677/foreign_bridge.test.js
@@ -111,6 +111,9 @@ contract('ForeignAMBErc677ToErc677', async accounts => {
       // Then
       const events = await getEvents(ambBridgeContract, { event: 'UserRequestForAffirmation' })
       expect(events.length).to.be.equal(1)
+      const data = `0x${events[0].returnValues.encodedData.slice(2 + 40 + 40 + 66)}`
+      const hash = web3.utils.soliditySha3(data)
+      expect(await foreignBridge.messageHashRecipient(hash)).to.be.equal(user) // should keep message sender instead of alternative receiver messageHashRecipient
       expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
       expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(halfEther)
     })

--- a/test/amb_erc677_to_erc677/foreign_bridge.test.js
+++ b/test/amb_erc677_to_erc677/foreign_bridge.test.js
@@ -111,9 +111,6 @@ contract('ForeignAMBErc677ToErc677', async accounts => {
       // Then
       const events = await getEvents(ambBridgeContract, { event: 'UserRequestForAffirmation' })
       expect(events.length).to.be.equal(1)
-      const data = `0x${events[0].returnValues.encodedData.slice(2 + 40 + 40 + 66)}`
-      const hash = web3.utils.soliditySha3(data)
-      expect(await foreignBridge.messageHashRecipient(hash)).to.be.equal(user) // should keep message sender instead of alternative receiver messageHashRecipient
       expect(events[0].returnValues.encodedData.includes(strip0x(user2).toLowerCase())).to.be.equal(true)
       expect(await foreignBridge.totalSpentPerDay(currentDay)).to.be.bignumber.equal(halfEther)
     })


### PR DESCRIPTION
It was found that fixed tokens receiver is different from the tokens sender when an alternative receiver is used in the mediator contracts, see https://github.com/poanetwork/tokenbridge-contracts/pull/394#discussion_r409623160

In order to fix this, it is proposed to save an actual tokens sender instead of chosen receiver here:
https://github.com/poanetwork/tokenbridge-contracts/blob/0ef9071a0d39dcf59a09a5304cbafb711901d1b2/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol#L80