### PR TITLE
Synchronization of interfaces version with the release versioning

### DIFF
--- a/contracts/upgradeable_contracts/VersionableBridge.sol
+++ b/contracts/upgradeable_contracts/VersionableBridge.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 contract VersionableBridge {
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (3, 0, 0);
+        return (4, 1, 0);
     }
 
     /* solcov ignore next */


### PR DESCRIPTION
During a code inspection it was found that the bridge interfaces version is inconsistent with the release version. But [the bridge API was changed](https://github.com/poanetwork/tokenbridge-contracts/pull/357) as so it is not compatible any more with the contracts of version 3.0.0