### PR TITLE
Remove redundant asserts in Zero DSR tests

### DIFF
--- a/test/erc_to_native/foreign_bridge.test.js
+++ b/test/erc_to_native/foreign_bridge.test.js
@@ -2145,8 +2145,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
 
           await foreignBridge.executeSignatures(message, oneSignature).should.be.fulfilled
         }
-
-        expect(await foreignBridge.dsrBalance()).to.be.bignumber.lt(ether('7.4'))
       })
 
       it('should allow to executeSignatures when DSR is zero with many conversions', async () => {
@@ -2170,8 +2168,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
 
           await foreignBridge.executeSignatures(message, oneSignature).should.be.fulfilled
         }
-
-        expect(await foreignBridge.dsrBalance()).to.be.bignumber.lt(ether('0.4'))
       })
 
       it('should allow to executeSignatures after pay interest', async () => {
@@ -2203,8 +2199,6 @@ contract('ForeignBridge_ERC20_to_Native', async accounts => {
 
           await foreignBridge.executeSignatures(message, oneSignature).should.be.fulfilled
         }
-
-        expect(await foreignBridge.dsrBalance()).to.be.bignumber.lt(ether('7.4'))
       })
     })
   })


### PR DESCRIPTION
As it was found in https://github.com/poanetwork/tokenbridge-contracts/pull/410#issuecomment-623323516, https://travis-ci.org/github/poanetwork/tokenbridge-contracts/jobs/682811252 , tests for disabled DSR can behave differently.
This happens because of the great amount of delays in these tests and the fact that runs with enabled coverage are much slower.

This PR removes all asserts which rely on a particular timing.