### PR TITLE
Hiding of fee distribution implementation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,15 @@
 node_modules
 deploy/node_modules
 .git
+.gitignore
 .dockerignore
 deploy/.env
+deploy/*.config
 docker-compose.yml
 Dockerfile
 *.log
 flats
+contracts.sublime-project
+contracts.sublime-workspace
+upgrade/.env*
+!upgrade/.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ flats
 coverage
 *.sublime-*
 .0x-artifacts
+upgrade/.env*
+deploy/.env
+deploy/*.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,25 @@ COPY ./upgrade/package.json ./upgrade/
 COPY ./upgrade/package-lock.json ./upgrade/
 RUN cd ./upgrade; npm install; cd ..
 
-COPY . .
+COPY ./scripts ./scripts
+
+COPY truffle-config.js truffle-config.js
+COPY ./contracts ./contracts
 RUN npm run compile
+
+COPY flatten.sh flatten.sh
 RUN bash flatten.sh
+
+COPY .eslintignore .eslintignore
+COPY .eslintrc .eslintrc
+COPY .prettierrc .prettierrc
+
+COPY ./upgrade ./upgrade
+COPY deploy.sh deploy.sh
+COPY ./deploy ./deploy
+COPY .solhint.json .solhint.json
+COPY codechecks.yml codechecks.yml
+COPY ./test ./test
 
 ENV PATH="/contracts/:${PATH}"
 ENV NOFLAT=true

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
@@ -64,6 +64,14 @@ contract HomeStakeTokenFeeManager is BlockRewardBridge, Ownable {
     }
 
     /**
+     * @dev Returns the state of the fee manager configuration: whether
+     * it is ready to collect and distribute fee or not.
+     */
+    function isFeeCollectingActivated() public view returns (bool) {
+        return ((address(_blockRewardContract()) != address(0)) && (getFee() > 0));
+    }
+
+    /**
      * @dev Distributes fee as per the logic of the fee manager.
      * In this particular case, the amount of fee is passed the block 
      * reward contract which will mint new tokens and distribute them

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
@@ -45,7 +45,8 @@ contract HomeStakeTokenFeeManager is BlockRewardBridge, Ownable {
     }
 
     /**
-     * @dev Sets the fee percentage amount for the mediator operations. Only the owner can call this method.
+     * @dev Sets the fee percentage amount for the mediator operations.
+     * Only the owner can call this method.
      * @param _fee the fee percentage
      */
     function setFee(uint256 _fee) external onlyOwner {
@@ -60,5 +61,18 @@ contract HomeStakeTokenFeeManager is BlockRewardBridge, Ownable {
         require(_fee < MAX_FEE);
         uintStorage[FEE] = _fee;
         emit FeeUpdated(_fee);
+    }
+
+    /**
+     * @dev Distributes fee as per the logic of the fee manager.
+     * In this particular case, the amount of fee is passed the block 
+     * reward contract which will mint new tokens and distribute them
+     * among the stakers.
+     * @param _fee amount of tokens to be distributed
+     */
+    function _distributeFee(uint256 _fee) internal {
+        if (address(_blockRewardContract()) != address(0)) {
+            _blockRewardContract().addBridgeTokenRewardReceivers(fee);
+        }
     }
 }

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
@@ -72,7 +72,7 @@ contract HomeStakeTokenFeeManager is BlockRewardBridge, Ownable {
      */
     function _distributeFee(uint256 _fee) internal {
         if (address(_blockRewardContract()) != address(0)) {
-            _blockRewardContract().addBridgeTokenRewardReceivers(fee);
+            _blockRewardContract().addBridgeTokenRewardReceivers(_fee);
         }
     }
 }

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenFeeManager.sol
@@ -76,11 +76,11 @@ contract HomeStakeTokenFeeManager is BlockRewardBridge, Ownable {
      * In this particular case, the amount of fee is passed the block 
      * reward contract which will mint new tokens and distribute them
      * among the stakers.
+     * IMPORTANT: make sure that the code checks that the block reward
+     * contract is initialized before calling this method.
      * @param _fee amount of tokens to be distributed
      */
     function _distributeFee(uint256 _fee) internal {
-        if (address(_blockRewardContract()) != address(0)) {
-            _blockRewardContract().addBridgeTokenRewardReceivers(_fee);
-        }
+        _blockRewardContract().addBridgeTokenRewardReceivers(_fee);
     }
 }

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
@@ -2,7 +2,6 @@ pragma solidity 0.4.24;
 
 import "../../interfaces/IMintHandler.sol";
 import "./BasicStakeTokenMediator.sol";
-import "../BlockRewardBridge.sol";
 import "./HomeStakeTokenFeeManager.sol";
 import "../../interfaces/IBurnableMintableERC677Token.sol";
 
@@ -148,7 +147,7 @@ contract HomeStakeTokenMediator is BasicStakeTokenMediator, HomeStakeTokenFeeMan
                 // the fee manager will take care about fee distribution
                 _distributeFee(fee);
             } else {
-                // fee is zero if the fee manager is not configured or 
+                // fee is zero if the fee manager is not configured or
                 // no fees are collected from token transfers
                 passMessage(_from, chooseReceiver(_from, _data), _value);
             }

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
@@ -141,17 +141,16 @@ contract HomeStakeTokenMediator is BasicStakeTokenMediator, HomeStakeTokenFeeMan
             // burn all incoming tokens
             IBurnableMintableERC677Token(_token).burn(_value);
 
-            if (address(_blockRewardContract()) == address(0)) {
-                // in case if block reward contract is not configured, the fee is not collected
-                passMessage(_from, chooseReceiver(_from, _data), _value);
-            } else {
-                // when block reward contract is defined, the calculated fee is subtracted from the original value
-                uint256 fee = calculateFee(_value);
+            uint256 fee = calculateFee(_value);
+            if (fee > 0) {
+                // the calculated fee is subtracted from the original value
                 passMessage(_from, chooseReceiver(_from, _data), _value.sub(fee));
-                if (fee > 0) {
-                    // the fee itself is distributed later in the block reward contract
-                    _blockRewardContract().addBridgeTokenRewardReceivers(fee);
-                }
+                // the fee manager will take care about fee distribution
+                _distributeFee(fee);
+            } else {
+                // fee is zero if the fee manager is not configured or 
+                // no fees are collected from token transfers
+                passMessage(_from, chooseReceiver(_from, _data), _value);
             }
         }
     }

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/HomeStakeTokenMediator.sol
@@ -140,15 +140,15 @@ contract HomeStakeTokenMediator is BasicStakeTokenMediator, HomeStakeTokenFeeMan
             // burn all incoming tokens
             IBurnableMintableERC677Token(_token).burn(_value);
 
-            uint256 fee = calculateFee(_value);
-            if (fee > 0) {
+            if (isFeeCollectingActivated()) {
+                uint256 fee = calculateFee(_value);
                 // the calculated fee is subtracted from the original value
                 passMessage(_from, chooseReceiver(_from, _data), _value.sub(fee));
-                // the fee manager will take care about fee distribution
-                _distributeFee(fee);
+                if (fee > 0) {
+                    // the fee manager will take care about fee distribution
+                    _distributeFee(fee);
+                }
             } else {
-                // fee is zero if the fee manager is not configured or
-                // no fees are collected from token transfers
                 passMessage(_from, chooseReceiver(_from, _data), _value);
             }
         }

--- a/test/stake_token_mediators/home_mediator.test.js
+++ b/test/stake_token_mediators/home_mediator.test.js
@@ -198,6 +198,31 @@ contract('HomeStakeTokenMediator', async accounts => {
       })
     })
 
+    describe('isFeeCollectingActivated', async () => {
+      it('should return false when no block reward and no fee', async () => {
+        expect(await homeMediator.isFeeCollectingActivated()).to.be.equal(false)
+      })
+
+      it('should return false when block reward is configured but no fee', async () => {
+        await homeMediator.setBlockRewardContract(blockReward.address)
+
+        expect(await homeMediator.isFeeCollectingActivated()).to.be.equal(false)
+      })
+
+      it('should return false when no block reward but fee is set', async () => {
+        await homeMediator.setFee(ether('0.05'), { from: owner }).should.be.fulfilled
+
+        expect(await homeMediator.isFeeCollectingActivated()).to.be.equal(false)
+      })
+
+      it('should return true when both block reward and fee are configured', async () => {
+        await homeMediator.setFee(ether('0.05'), { from: owner }).should.be.fulfilled
+        await homeMediator.setBlockRewardContract(blockReward.address)
+
+        expect(await homeMediator.isFeeCollectingActivated()).to.be.equal(true)
+      })
+    })
+
     describe('calculateFee', async () => {
       it('should calculate fee for given value', async () => {
         expect(await homeMediator.calculateFee(ether('0'))).to.be.bignumber.equal(ZERO)


### PR DESCRIPTION
Logically the mediator should not be aware about the process how fees are distributed, this should lay on the fee manager shoulders. That's why the code to send fee to the block reward contract was moved to the fee manager.