### PR TITLE
Fix infinite AMB message loop

### DIFF
--- a/contracts/mocks/AMBMock.sol
+++ b/contracts/mocks/AMBMock.sol
@@ -42,6 +42,7 @@ contract AMBMock {
     }
 
     function requireToPassMessage(address _contract, bytes _data, uint256 _gas) external returns (bytes32) {
+        require(messageId == bytes32(0));
         bytes32 bridgeId = keccak256(abi.encodePacked(uint16(1337), address(this))) &
             0x00000000ffffffffffffffffffffffffffffffffffffffff0000000000000000;
 

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
@@ -4,10 +4,9 @@ import "../../libraries/Message.sol";
 import "../../libraries/ArbitraryMessage.sol";
 import "./BasicAMB.sol";
 import "./MessageDelivery.sol";
-import "./MessageProcessor.sol";
 import "../MessageRelay.sol";
 
-contract BasicForeignAMB is BasicAMB, MessageRelay, MessageDelivery, MessageProcessor {
+contract BasicForeignAMB is BasicAMB, MessageRelay, MessageDelivery {
     /**
     * @dev Validates provided signatures and relays a given message
     * @param _data bytes to be relayed

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
@@ -4,9 +4,8 @@ import "../../libraries/Message.sol";
 import "../../libraries/ArbitraryMessage.sol";
 import "./BasicAMB.sol";
 import "./MessageDelivery.sol";
-import "./MessageProcessor.sol";
 
-contract BasicHomeAMB is BasicAMB, MessageDelivery, MessageProcessor {
+contract BasicHomeAMB is BasicAMB, MessageDelivery {
     event SignedForUserRequest(address indexed signer, bytes32 messageHash);
     event SignedForAffirmation(address indexed signer, bytes32 messageHash);
 

--- a/test/amb_native_to_erc20/foreign_mediator.test.js
+++ b/test/amb_native_to_erc20/foreign_mediator.test.js
@@ -1541,6 +1541,7 @@ contract('ForeignAMBNativeToErc20', async accounts => {
 
       const initialBalanceRewardAddress1 = await token.balanceOf(rewardAccountList[0])
       const initialBalanceRewardAddress2 = await token.balanceOf(rewardAccountList[1])
+      const initialBalanceRewardAddress3 = await token.balanceOf(rewardAccountList[2])
 
       await ambBridgeContract.executeMessageCall(
         contract.address,
@@ -1561,17 +1562,15 @@ contract('ForeignAMBNativeToErc20', async accounts => {
       const erc20Token = await ERC20Mock.at(token.address)
       const transferEvents = await getEvents(erc20Token, { event: 'Transfer' })
       // 5 transfer events: 1 Mint to user, 1 Mint to fee manager, fee manager 1 transfer to each reward account,
-      // 1 feeReceiver contract transfer to mediator, 1 transfer to 0 to burn the tokens
-      expect(transferEvents.length).to.be.equal(7)
+      // bridge should not allow to send messages in backward direction, so fee manager should not be able to send tokens through the bridge
+      expect(transferEvents.length).to.be.equal(5)
 
       const burnEvents = await getEvents(token, { event: 'Burn' })
-      expect(burnEvents.length).to.be.equal(1)
+      expect(burnEvents.length).to.be.equal(0)
 
       const totalSupply = await token.totalSupply()
 
-      expect(totalSupply.eq(value.sub(feePerValidator)) || totalSupply.eq(value.sub(feePerValidatorPlusDiff))).to.equal(
-        true
-      )
+      expect(totalSupply).to.be.bignumber.equal(value)
 
       expect(await token.balanceOf(user)).to.be.bignumber.equal(finalUserValue)
 
@@ -1587,7 +1586,10 @@ contract('ForeignAMBNativeToErc20', async accounts => {
         updatedBalanceRewardAddress2.eq(initialBalanceRewardAddress2.add(feePerValidator)) ||
           updatedBalanceRewardAddress2.eq(initialBalanceRewardAddress2.add(feePerValidatorPlusDiff))
       ).to.equal(true)
-      expect(updatedBalanceRewardAddress3).to.be.bignumber.equal(ZERO)
+      expect(
+        updatedBalanceRewardAddress3.eq(initialBalanceRewardAddress3.add(feePerValidator)) ||
+          updatedBalanceRewardAddress3.eq(initialBalanceRewardAddress3.add(feePerValidatorPlusDiff))
+      ).to.equal(true)
 
       const feeEvents = await getEvents(contract, { event: 'FeeDistributed' })
       expect(feeEvents.length).to.be.equal(1)
@@ -1661,6 +1663,7 @@ contract('ForeignAMBNativeToErc20', async accounts => {
 
       expect(await ambBridgeContract.messageCallStatus(failedMessageId)).to.be.equal(false)
 
+      const initialBalanceRewardAddress1 = await token.balanceOf(rewardAccountList[0])
       const initialBalanceRewardAddress2 = await token.balanceOf(rewardAccountList[1])
       const initialBalanceRewardAddress3 = await token.balanceOf(rewardAccountList[2])
 
@@ -1684,16 +1687,14 @@ contract('ForeignAMBNativeToErc20', async accounts => {
       const transferEvents = await getEvents(erc20Token, { event: 'Transfer' })
       // 5 transfer events: 1 Mint to user, 1 Mint to fee manager, fee manager 1 transfer to each reward account,
       // 1 feeReceiver contract transfer to mediator, 1 transfer to 0 to burn the tokens
-      expect(transferEvents.length).to.be.equal(7)
+      expect(transferEvents.length).to.be.equal(5)
 
       const burnEvents = await getEvents(token, { event: 'Burn' })
-      expect(burnEvents.length).to.be.equal(1)
+      expect(burnEvents.length).to.be.equal(0)
 
       const totalSupply = await token.totalSupply()
 
-      expect(totalSupply.eq(value.sub(feePerValidator)) || totalSupply.eq(value.sub(feePerValidatorPlusDiff))).to.equal(
-        true
-      )
+      expect(totalSupply).to.be.bignumber.equal(value)
 
       expect(await token.balanceOf(user)).to.be.bignumber.equal(finalUserValue)
 
@@ -1701,7 +1702,10 @@ contract('ForeignAMBNativeToErc20', async accounts => {
       const updatedBalanceRewardAddress2 = await token.balanceOf(rewardAccountList[1])
       const updatedBalanceRewardAddress3 = await token.balanceOf(rewardAccountList[2])
 
-      expect(updatedBalanceRewardAddress1).to.be.bignumber.equal(ZERO)
+      expect(
+        updatedBalanceRewardAddress1.eq(initialBalanceRewardAddress1.add(feePerValidator)) ||
+          updatedBalanceRewardAddress1.eq(initialBalanceRewardAddress1.add(feePerValidatorPlusDiff))
+      ).to.equal(true)
       expect(
         updatedBalanceRewardAddress2.eq(initialBalanceRewardAddress2.add(feePerValidator)) ||
           updatedBalanceRewardAddress2.eq(initialBalanceRewardAddress2.add(feePerValidatorPlusDiff))

--- a/test/arbitrary_message/home_bridge.test.js
+++ b/test/arbitrary_message/home_bridge.test.js
@@ -632,6 +632,25 @@ contract('HomeAMB', async accounts => {
 
       await homeBridge.executeAffirmation(message, { from: authorities[0], gasPrice }).should.be.rejected
     })
+    it('should not allow to pass message back through the bridge', async () => {
+      const user = accounts[8]
+
+      const data = await homeBridge.contract.methods.requireToPassMessage(box.address, setValueData, 100000).encodeABI()
+      // Use these calls to simulate home bridge on home network
+      const resultPassMessageTx = await foreignBridge.requireToPassMessage(homeBridge.address, data, 821254, {
+        from: user
+      })
+
+      const { encodedData: message, messageId } = resultPassMessageTx.logs[0].args
+
+      await homeBridge.executeAffirmation(message, {
+        from: authorities[0],
+        gasPrice
+      }).should.be.fulfilled
+
+      // means that call to requireToPassMessage inside MessageProcessor reverted, since messageId flag was set up
+      expect(await homeBridge.messageCallStatus(messageId)).to.be.equal(false)
+    })
   })
   describe('submitSignature', () => {
     let homeBridge


### PR DESCRIPTION
It was discovered, that it is not safe to allow passing messages while other message is currently processed. Specially formatted message can trigger an infinite loop, and eventually, all validators will burn their balance on gas expenses.

In order to fix this, the following restriction is introduced:
https://github.com/poanetwork/tokenbridge-contracts/blob/69c8f0bc94ff013d9317808076734a7a4feaf69a/contracts/upgradeable_contracts/arbitrary_message/MessageDelivery.sol#L19-L20

This check will also make it impossible to bridge received fee in the same transaction, although it was possible to do so in the `AMB_NATIVE_TO_ERC` mode before.
