### PR TITLE
methods to be used in migration from vanilla bridge to AMB mediators

### DIFF
--- a/contracts/upgradeable_contracts/amb_native_to_erc20/ForeignAMBNativeToErc20.sol
+++ b/contracts/upgradeable_contracts/amb_native_to_erc20/ForeignAMBNativeToErc20.sol
@@ -208,4 +208,38 @@ contract ForeignAMBNativeToErc20 is BasicAMBNativeToErc20, ReentrancyGuard, Base
         // remove the lock
         disableMessagesRestriction();
     }
+
+    /**
+    * @dev Method to migrate foreign WETC native-to-erc bridge to a
+    * mediator implementation on top of AMB
+    */
+    function migrateToMediator() external {
+        bytes32 REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
+        bytes32 GAS_PRICE = 0x55b3774520b5993024893d303890baa4e84b1244a43c60034d1ced2d3cf2b04b; // keccak256(abi.encodePacked("gasPrice"))
+        bytes32 DEPLOYED_AT_BLOCK = 0xb120ceec05576ad0c710bc6e85f1768535e27554458f05dcbb5c65b8c7a749b0; // keccak256(abi.encodePacked("deployedAtBlock"))
+        bytes32 HOME_FEE_STORAGE_KEY = 0xc3781f3cec62d28f56efe98358f59c2105504b194242dbcb2cc0806850c306e7; // keccak256(abi.encodePacked("homeFee"))
+        bytes32 FOREIGN_FEE_STORAGE_KEY = 0x68c305f6c823f4d2fa4140f9cf28d32a1faccf9b8081ff1c2de11cf32c733efc; // keccak256(abi.encodePacked("foreignFee"))
+        bytes32 VALIDATOR_CONTRACT = 0x5a74bb7e202fb8e4bf311841c7d64ec19df195fee77d7e7ae749b27921b6ddfe; // keccak256(abi.encodePacked("validatorContract"))
+
+        bytes32 migrationToMediatorStorage = 0x131ab4848a6da904c5c205972a9dfe59f6d2afb8c9c3acd56915f89558369213; // keccak256(abi.encodePacked("migrationToMediator"))
+        require(!boolStorage[migrationToMediatorStorage]);
+
+        // Assign new AMB parameters
+        _setBridgeContract(0x0); // Will be filled with a value later
+        _setMediatorContractOnOtherSide(0x0); // Will be filled with a value later
+        _setRequestGasLimit(500000);
+
+        // Update fee manager
+        addressStorage[FEE_MANAGER_CONTRACT] = 0x0; // Will be filled with a value later
+
+        // Free old storage
+        delete addressStorage[VALIDATOR_CONTRACT];
+        delete uintStorage[GAS_PRICE];
+        delete uintStorage[DEPLOYED_AT_BLOCK];
+        delete uintStorage[REQUIRED_BLOCK_CONFIRMATIONS];
+        delete uintStorage[HOME_FEE_STORAGE_KEY];
+        delete uintStorage[FOREIGN_FEE_STORAGE_KEY];
+
+        boolStorage[migrationToMediatorStorage] = true;
+    }
 }

--- a/contracts/upgradeable_contracts/amb_native_to_erc20/HomeAMBNativeToErc20.sol
+++ b/contracts/upgradeable_contracts/amb_native_to_erc20/HomeAMBNativeToErc20.sol
@@ -159,4 +159,45 @@ contract HomeAMBNativeToErc20 is BasicAMBNativeToErc20 {
         setMediatorBalance(mediatorBalance().add(diff));
         passMessage(_receiver, _receiver, diff);
     }
+
+    /**
+    * @dev Method to migrate home WETC native-to-erc bridge to a mediator
+    * implementation on top of AMB
+    */
+    function migrateToMediator() external {
+        bytes32 REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
+        bytes32 GAS_PRICE = 0x55b3774520b5993024893d303890baa4e84b1244a43c60034d1ced2d3cf2b04b; // keccak256(abi.encodePacked("gasPrice"))
+        bytes32 DEPLOYED_AT_BLOCK = 0xb120ceec05576ad0c710bc6e85f1768535e27554458f05dcbb5c65b8c7a749b0; // keccak256(abi.encodePacked("deployedAtBlock"))
+        bytes32 HOME_FEE_STORAGE_KEY = 0xc3781f3cec62d28f56efe98358f59c2105504b194242dbcb2cc0806850c306e7; // keccak256(abi.encodePacked("homeFee"))
+        bytes32 FOREIGN_FEE_STORAGE_KEY = 0x68c305f6c823f4d2fa4140f9cf28d32a1faccf9b8081ff1c2de11cf32c733efc; // keccak256(abi.encodePacked("foreignFee"))
+        bytes32 VALIDATOR_CONTRACT = 0x5a74bb7e202fb8e4bf311841c7d64ec19df195fee77d7e7ae749b27921b6ddfe; // keccak256(abi.encodePacked("validatorContract"))
+
+        bytes32 migrationToMediatorStorage = 0x131ab4848a6da904c5c205972a9dfe59f6d2afb8c9c3acd56915f89558369213; // keccak256(abi.encodePacked("migrationToMediator"))
+        require(!boolStorage[migrationToMediatorStorage]);
+
+        // Assign new AMB parameters
+        _setBridgeContract(0x0); // Will be filled with a value later
+        _setMediatorContractOnOtherSide(0x0); // Will be filled with a value later
+        _setRequestGasLimit(500000);
+
+        // Update fee manager
+        addressStorage[FEE_MANAGER_CONTRACT] = 0x0; // Will be filled with a value later
+
+        // Set the balance of the mediator contract
+        setMediatorBalance(address(this).balance);
+
+        // Free old storage
+        delete addressStorage[VALIDATOR_CONTRACT];
+        delete uintStorage[GAS_PRICE];
+        delete uintStorage[DEPLOYED_AT_BLOCK];
+        delete uintStorage[REQUIRED_BLOCK_CONFIRMATIONS];
+        delete uintStorage[HOME_FEE_STORAGE_KEY];
+        delete uintStorage[FOREIGN_FEE_STORAGE_KEY];
+
+        // Free storage related to proxy size returns.
+        delete uintStorage[0x5e16d82565fc7ee8775cc18db290ff4010745d3fd46274a7bc7ddbebb727fa54]; // keccak256(abi.encodePacked("dataSizes", bytes4(keccak256("signature(bytes32,uint256)"))))
+        delete uintStorage[0x3b0a1ac531be1657049cf649eca2510ce9e3ef7df1be26d5c248fe8b298f4374]; // keccak256(abi.encodePacked("dataSizes", bytes4(keccak256("message(bytes32)"))))
+
+        boolStorage[migrationToMediatorStorage] = true;
+    }
 }


### PR DESCRIPTION
This PR is to review the logic of migration the WETC vanilla bridge to AMB mediators. 

**It will not be merged to any branch after approval**.

The current WETC vanilla bridge contracts:
* [Home](https://blockscout.com/etc/mainnet/address/0x073081832b4ecdce79d4d6753565c85ba4b3bea9)
* [Foreign](https://etherscan.io/address/0x0cb781ee62f815bdd9cd4c2210ae8600d43e7040)
* [WETC token](https://etherscan.io/token/0x86aabcc646f290b9fc9bd05ce17c3858d1511da1)

Here is the test I did:

1. Deploy the vanilla `native-to-erc20` bridge between Kovan (Foreign) and Sokol (Home, `HOME_EVM_VERSION=spuriousDragon`)
```json
{
    "homeBridge": {
        "address": "0x22761c8D4230E0629205A035a2Ec8D2E4d457CFd",
        "deployedBlockNumber": 15154941
    },
    "foreignBridge": {
        "address": "0xd99F8C9455cD900f24c7E8beBb79123EFA88dE02",
        "deployedBlockNumber": 18995817,
        "erc677": {
            "address": "0xf4BA99DfBAd5b8f803Be317b1Eac7651938F3d47"
        }
    }
}
```
2. Deploy the oracle
3. Make a test transactions in both directions
4. Modify the mediator contracts as suggested in this PR, use the existing Kovan-Sokol AMB bridge contracts to specify the bridge contract addresses.
5. Manually deploy the fee manager on Sokol. The constructor parameters are:
```
"0xe4c2820ec69410907f312b7487af3dfb32640c33", 1000000000000000, ["0xe4c2820ec69410907f312b7487af3dfb32640c33"], "0x22761c8D4230E0629205A035a2Ec8D2E4d457CFd"
```
7. Manually deploy the fee manager on Kovan. The constructor parameters are:
```
"0xe4c2820ec69410907f312b7487af3dfb32640c33", 1000000000000000, ["0xe4c2820ec69410907f312b7487af3dfb32640c33"], "0xd99F8C9455cD900f24c7E8beBb79123EFA88dE02", "0xf4BA99DfBAd5b8f803Be317b1Eac7651938F3d47"
```
8. Manually deploy mediators
9. Upgrade the vanilla bridge contract to the mediator's implementation at the Foreign side by calling the `upgradeAndCall`, the `migrateToMediator` method selector is `0x798e9289`.
10. Upgrade the vanilla bridge contract to the mediator's implementation at the Home side by calling the `upgradeAndCall`, the `migrateToMediator` method selector is `0x798e9289`.
11. Make a test transactions in both directions
12. Make transactions by using the alternative receiver feature.
