### PR TITLE
Bump version to 5.0.2 before merging to master

### DIFF
--- a/contracts/upgradeable_contracts/amb_native_to_erc20/BasicAMBNativeToErc20.sol
+++ b/contracts/upgradeable_contracts/amb_native_to_erc20/BasicAMBNativeToErc20.sol
@@ -75,7 +75,7 @@ contract BasicAMBNativeToErc20 is
     * @return patch value of the version
     */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 0, 0);
+        return (1, 0, 1);
     }
 
     /**

--- a/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
@@ -17,6 +17,6 @@ contract VersionableAMB is VersionableBridge {
      * @return (major, minor, patch) version triple
      */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (5, 0, 1);
+        return (5, 0, 2);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This version tag will contain the fix for the issue with imbalance of the native-to-erc20 AMB extension and an improvement to provide getters to get source and destination chain ids from AMB contract.