### PR TITLE
Bump version to 5.1.0 before merging to master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-bridge-contracts",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This version tag will contain a new pair of the AMB mediators to provide ability to transfer an ERC20 token to the native coin similarly to the xDai bridge.