### PR TITLE
Use permittable ERC677 token by default for AMB mediators

### DIFF
--- a/contracts/PermittableToken.sol
+++ b/contracts/PermittableToken.sol
@@ -138,4 +138,9 @@ contract PermittableToken is ERC677BridgeToken {
     function _now() internal view returns (uint256) {
         return now;
     }
+
+    /// @dev Version of the token contract.
+    function getTokenInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
+        return (2, 3, 0);
+    }
 }

--- a/deploy/src/amb_erc677_to_erc677/home.js
+++ b/deploy/src/amb_erc677_to_erc677/home.js
@@ -24,7 +24,7 @@ const {
   homeContracts: {
     EternalStorageProxy,
     HomeAMBErc677ToErc677: HomeBridge,
-    ERC677BridgeToken,
+    ERC677BridgeTokenPermittable,
     ERC677BridgeTokenRewardable
   }
 } = require('../loadContracts')
@@ -61,13 +61,10 @@ async function deployHome() {
   nonce++
 
   console.log('\n[Home] deploying Bridgeable token')
-  const erc677Contract = DEPLOY_REWARDABLE_TOKEN ? ERC677BridgeTokenRewardable : ERC677BridgeToken
-  let args = [BRIDGEABLE_TOKEN_NAME, BRIDGEABLE_TOKEN_SYMBOL, BRIDGEABLE_TOKEN_DECIMALS]
-  if (DEPLOY_REWARDABLE_TOKEN) {
-    const chainId = await web3Home.eth.getChainId()
-    assert.strictEqual(chainId > 0, true, 'Invalid chain ID')
-    args.push(chainId)
-  }
+  const erc677Contract = DEPLOY_REWARDABLE_TOKEN ? ERC677BridgeTokenRewardable : ERC677BridgeTokenPermittable
+  const chainId = await web3Home.eth.getChainId()
+  assert.strictEqual(chainId > 0, true, 'Invalid chain ID')
+  const args = [BRIDGEABLE_TOKEN_NAME, BRIDGEABLE_TOKEN_SYMBOL, BRIDGEABLE_TOKEN_DECIMALS, chainId]
   const erc677token = await deployContract(
     erc677Contract,
     args,

--- a/deploy/src/amb_native_to_erc20/foreign.js
+++ b/deploy/src/amb_native_to_erc20/foreign.js
@@ -17,7 +17,7 @@ const {
     ForeignAMBNativeToErc20: ForeignBridge,
     ForeignFeeManagerAMBNativeToErc20,
     ERC677BridgeTokenRewardable,
-    ERC677BridgeToken
+    ERC677BridgeTokenPermittable
   }
 } = require('../loadContracts')
 const {
@@ -71,10 +71,13 @@ async function deployForeign() {
   nonce++
 
   console.log('\n[Foreign] Deploying Bridgeable token')
-  const erc677Contract = DEPLOY_REWARDABLE_TOKEN ? ERC677BridgeTokenRewardable : ERC677BridgeToken
+  const erc677Contract = DEPLOY_REWARDABLE_TOKEN ? ERC677BridgeTokenRewardable : ERC677BridgeTokenPermittable
+  const chainId = await web3Foreign.eth.getChainId()
+  assert.strictEqual(chainId > 0, true, 'Invalid chain ID')
+  const args = [BRIDGEABLE_TOKEN_NAME, BRIDGEABLE_TOKEN_SYMBOL, BRIDGEABLE_TOKEN_DECIMALS, chainId]
   const erc677token = await deployContract(
     erc677Contract,
-    [BRIDGEABLE_TOKEN_NAME, BRIDGEABLE_TOKEN_SYMBOL, BRIDGEABLE_TOKEN_DECIMALS],
+    args,
     { from: DEPLOYMENT_ACCOUNT_ADDRESS, network: 'foreign', nonce }
   )
   nonce++

--- a/deploy/src/loadContracts.js
+++ b/deploy/src/loadContracts.js
@@ -21,6 +21,7 @@ function getContracts(evmVersion) {
     HomeBridgeErcToErcPOSDAO: require(`../../build/${buildPath}/HomeBridgeErcToErcPOSDAO.json`),
     ERC677BridgeToken: require(`../../build/${buildPath}/ERC677BridgeToken.json`),
     ERC677BridgeTokenRewardable: require(`../../build/${buildPath}/ERC677BridgeTokenRewardable.json`),
+    ERC677BridgeTokenPermittable: require(`../../build/${buildPath}/PermittableToken.json`),
     ForeignBridgeErcToNative: require(`../../build/${buildPath}/ForeignBridgeErcToNative.json`),
     FeeManagerErcToNative: require(`../../build/${buildPath}/FeeManagerErcToNative.json`),
     FeeManagerErcToNativePOSDAO: require(`../../build/${buildPath}/FeeManagerErcToNativePOSDAO.json`),

--- a/deploy/src/utils/verifier.js
+++ b/deploy/src/utils/verifier.js
@@ -7,7 +7,7 @@ const { EXPLORER_TYPES, REQUEST_STATUS } = require('../constants')
 
 const basePath = path.join(__dirname, '..', '..', '..', 'flats')
 
-const isBridgeToken = name => name === 'ERC677BridgeToken.sol' || name === 'ERC677BridgeTokenRewardable.sol'
+const isBridgeToken = name => name === 'ERC677BridgeToken.sol' || name === 'ERC677BridgeTokenRewardable.sol' || name === 'PermittableToken.sol'
 const isValidators = name => name === 'BridgeValidators.sol' || name === 'RewardableValidators.sol'
 const isInterestReceiver = name => name === 'InterestReceiver.sol'
 

--- a/flatten.sh
+++ b/flatten.sh
@@ -23,7 +23,7 @@ ${FLATTENER} contracts/upgradeability/EternalStorageProxy.sol > flats/upgradeabi
 ${FLATTENER} contracts/upgradeability/ClassicEternalStorageProxy.sol > flats/upgradeability/ClassicEternalStorageProxy_flat.sol
 ${FLATTENER} contracts/ERC677BridgeToken.sol > flats/ERC677BridgeToken_flat.sol
 ${FLATTENER} contracts/ERC677BridgeTokenRewardable.sol > flats/ERC677BridgeTokenRewardable_flat.sol
-${FLATTENER} contracts/PermittableToken.sol > flats/ERC677BridgeTokenPermittable_flat.sol
+${FLATTENER} contracts/PermittableToken.sol > flats/PermittableToken_flat.sol
 
 echo "Flattening bridge validators contracts"
 ${FLATTENER} ${VALIDATOR_CONTRACTS_DIR}/BridgeValidators.sol > flats/validators/BridgeValidators_flat.sol

--- a/flatten.sh
+++ b/flatten.sh
@@ -23,6 +23,7 @@ ${FLATTENER} contracts/upgradeability/EternalStorageProxy.sol > flats/upgradeabi
 ${FLATTENER} contracts/upgradeability/ClassicEternalStorageProxy.sol > flats/upgradeability/ClassicEternalStorageProxy_flat.sol
 ${FLATTENER} contracts/ERC677BridgeToken.sol > flats/ERC677BridgeToken_flat.sol
 ${FLATTENER} contracts/ERC677BridgeTokenRewardable.sol > flats/ERC677BridgeTokenRewardable_flat.sol
+${FLATTENER} contracts/PermittableToken.sol > flats/ERC677BridgeTokenPermittable_flat.sol
 
 echo "Flattening bridge validators contracts"
 ${FLATTENER} ${VALIDATOR_CONTRACTS_DIR}/BridgeValidators.sol > flats/validators/BridgeValidators_flat.sol


### PR DESCRIPTION
Closes #450 

This PR changes the behaviour of the deployment scripts as so the permittable token contract based on TokenBridge ERC677 implementation is used by default together with AMB mediators instead of the "vanilla" ERC677 token.