### PR TITLE
Create new Dockerfile for deployments/upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,10 @@
-FROM node:10
-
-RUN apt-get update
-RUN apt-get install -y netcat
-RUN apt-get clean
+FROM node:10 as contracts
 
 WORKDIR /contracts
 
 COPY package.json .
 COPY package-lock.json .
-RUN npm install
-
-COPY ./deploy/package.json ./deploy/
-COPY ./deploy/package-lock.json ./deploy/
-RUN cd ./deploy; npm install; cd ..
-
-COPY ./upgrade/package.json ./upgrade/
-COPY ./upgrade/package-lock.json ./upgrade/
-RUN cd ./upgrade; npm install; cd ..
-
-COPY ./scripts ./scripts
+RUN npm install --only=prod
 
 COPY truffle-config.js truffle-config.js
 COPY ./contracts ./contracts
@@ -27,16 +13,23 @@ RUN npm run compile
 COPY flatten.sh flatten.sh
 RUN bash flatten.sh
 
-COPY .eslintignore .eslintignore
-COPY .eslintrc .eslintrc
-COPY .prettierrc .prettierrc
+FROM node:10
+
+WORKDIR /contracts
+COPY --from=contracts /contracts/build ./build
+COPY --from=contracts /contracts/flats ./flats
+
+COPY ./deploy/package.json ./deploy/
+COPY ./deploy/package-lock.json ./deploy/
+RUN cd ./deploy; npm install --only=prod; cd ..
+
+COPY ./upgrade/package.json ./upgrade/
+COPY ./upgrade/package-lock.json ./upgrade/
+RUN cd ./upgrade; npm install --only=prod; cd ..
 
 COPY ./upgrade ./upgrade
 COPY deploy.sh deploy.sh
 COPY ./deploy ./deploy
-COPY .solhint.json .solhint.json
-COPY codechecks.yml codechecks.yml
-COPY ./test ./test
 
 ENV PATH="/contracts/:${PATH}"
 ENV NOFLAT=true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,42 @@
+FROM node:10
+
+RUN apt-get update
+RUN apt-get install -y netcat
+RUN apt-get clean
+
+WORKDIR /contracts
+
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+COPY ./deploy/package.json ./deploy/
+COPY ./deploy/package-lock.json ./deploy/
+RUN cd ./deploy; npm install; cd ..
+
+COPY ./upgrade/package.json ./upgrade/
+COPY ./upgrade/package-lock.json ./upgrade/
+RUN cd ./upgrade; npm install; cd ..
+
+COPY ./scripts ./scripts
+
+COPY truffle-config.js truffle-config.js
+COPY ./contracts ./contracts
+RUN npm run compile
+
+COPY flatten.sh flatten.sh
+RUN bash flatten.sh
+
+COPY .eslintignore .eslintignore
+COPY .eslintrc .eslintrc
+COPY .prettierrc .prettierrc
+
+COPY ./upgrade ./upgrade
+COPY deploy.sh deploy.sh
+COPY ./deploy ./deploy
+COPY .solhint.json .solhint.json
+COPY codechecks.yml codechecks.yml
+COPY ./test ./test
+
+ENV PATH="/contracts/:${PATH}"
+ENV NOFLAT=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,9 @@ services:
     build: .
     command: "true"
     env_file: ./deploy/.env
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: "true"
+    env_file: ./deploy/.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,7 +1273,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
       "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
-      "dev": true,
       "requires": {
         "debug": "^3.1.0",
         "request": "^2.85.0"
@@ -1283,7 +1282,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
       "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
-      "dev": true,
       "requires": {
         "@resolver-engine/core": "^0.2.1",
         "debug": "^3.1.0"
@@ -1293,7 +1291,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
       "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
-      "dev": true,
       "requires": {
         "@resolver-engine/core": "^0.2.1",
         "debug": "^3.1.0",
@@ -1304,7 +1301,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
       "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
-      "dev": true,
       "requires": {
         "@resolver-engine/fs": "^0.2.1",
         "@resolver-engine/imports": "^0.2.2",
@@ -24239,7 +24235,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.2.tgz",
       "integrity": "sha512-7qUIzaW8a4vI4nui14wsytht2oaqvqnZ1Iet2wRq2T0bCJ0wb6HByMKQhZKpU46R+n5BMTY4K5n+0ITyeNlmuQ==",
-      "dev": true,
       "requires": {
         "@resolver-engine/imports-fs": "^0.2.2",
         "find-up": "^2.1.0",
@@ -24252,7 +24247,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -24260,8 +24254,7 @@
         "solidity-parser-antlr": {
           "version": "0.4.11",
           "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
-          "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg==",
-          "dev": true
+          "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg=="
         }
       }
     },
@@ -24300,8 +24293,7 @@
     "tsort": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
-      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=",
-      "dev": true
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@0x/sol-trace": "^2.0.19",
     "@0x/subproviders": "^5.0.3",
     "openzeppelin-solidity": "1.12.0",
-    "truffle": "^5.0.35"
+    "truffle": "^5.0.35",
+    "truffle-flattener": "^1.4.2"
   },
   "devDependencies": {
     "@codechecks/client": "^0.1.9",
@@ -47,7 +48,6 @@
     "prettier": "^1.18.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.32",
     "solhint": "^2.2.0",
-    "solhint-plugin-prettier": "0.0.3",
-    "truffle-flattener": "^1.4.2"
+    "solhint-plugin-prettier": "0.0.3"
   }
 }


### PR DESCRIPTION
Closes #350 

Created a new Dockerfile that only has the required files for deployment and upgrades. In this case, the contracts are built and flattened in a build step of docker so all the dependencies are removed except for the required by the deployment or upgrade scripts.

The previous Dockerfile was renamed to Dockerfile.dev so it can be used for development purposes like compiling the contracts, running the test, coverage, etc.

Sizes of the docker images:
- tokenbridge-contracts_dev: `1.72GB`
- **new** tokenbridge-contracts_bridge-contracts: `1.13GB`