### PR TITLE
Increase the version of AMB contracts to 5.3.0

### DIFF
--- a/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
@@ -17,6 +17,6 @@ contract VersionableAMB is VersionableBridge {
      * @return (major, minor, patch) version triple
      */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (5, 0, 2);
+        return (5, 3, 0);
     }
 }


### PR DESCRIPTION
Although the modification of the AMB contracts was made under `5.3.0` it did not modify any public available behaviour of the code. Anyway, in order to simplify the upgrade paths in the future it make sense to reflect in the contract version method that the source of the contracts was changed.