### PR TITLE
Move fee manager into home mediator

### DIFF
--- a/contracts/mocks/PermittableTokenMock.sol
+++ b/contracts/mocks/PermittableTokenMock.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.4.24;
+
+import "../PermittableToken.sol";
+
+contract PermittableTokenMock is PermittableToken {
+    uint256 private _blockTimestamp;
+
+    constructor(string _name, string _symbol, uint8 _decimals, uint256 _chainId)
+        public
+        PermittableToken(_name, _symbol, _decimals, _chainId)
+    {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function setNow(uint256 _timestamp) public {
+        _blockTimestamp = _timestamp;
+    }
+
+    function _now() internal view returns (uint256) {
+        return _blockTimestamp != 0 ? _blockTimestamp : now;
+    }
+
+}

--- a/contracts/upgradeable_contracts/BasicAMBMediator.sol
+++ b/contracts/upgradeable_contracts/BasicAMBMediator.sol
@@ -15,6 +15,15 @@ contract BasicAMBMediator is Ownable {
     bytes32 internal constant REQUEST_GAS_LIMIT = 0x2dfd6c9f781bb6bbb5369c114e949b69ebb440ef3d4dd6b2836225eb1dc3a2be; // keccak256(abi.encodePacked("requestGasLimit"))
 
     /**
+    * @dev Throws if caller on the other side if not an associated mediator.
+    */
+    modifier onlyMediator {
+        require(msg.sender == address(bridgeContract()));
+        require(messageSender() == mediatorContractOnOtherSide());
+        _;
+    }
+
+    /**
     * @dev Sets the AMB bridge contract address. Only the owner can call this method.
     * @param _bridgeContract the address of the bridge contract.
     */

--- a/contracts/upgradeable_contracts/TokenBridgeMediator.sol
+++ b/contracts/upgradeable_contracts/TokenBridgeMediator.sol
@@ -40,9 +40,7 @@ contract TokenBridgeMediator is BasicAMBMediator, BasicTokenBridge, TransferInfo
     * @param _recipient address that will receive the tokens
     * @param _value amount of tokens to be received
     */
-    function handleBridgedTokens(address _recipient, uint256 _value) external {
-        require(msg.sender == address(bridgeContract()));
-        require(messageSender() == mediatorContractOnOtherSide());
+    function handleBridgedTokens(address _recipient, uint256 _value) external onlyMediator {
         if (withinExecutionLimit(_value)) {
             addTotalExecutedPerDay(getCurrentDay(), _value);
             executeActionOnBridgedTokens(_recipient, _value);
@@ -71,9 +69,7 @@ contract TokenBridgeMediator is BasicAMBMediator, BasicTokenBridge, TransferInfo
     * It uses the information stored by passMessage method when the assets were initially transferred
     * @param _messageId id of the message which execution failed on the other network.
     */
-    function fixFailedMessage(bytes32 _messageId) external {
-        require(msg.sender == address(bridgeContract()));
-        require(messageSender() == mediatorContractOnOtherSide());
+    function fixFailedMessage(bytes32 _messageId) external onlyMediator {
         require(!messageFixed(_messageId));
 
         address recipient = messageRecipient(_messageId);

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiTokenBridge.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiTokenBridge.sol
@@ -266,6 +266,10 @@ contract BasicMultiTokenBridge is EternalStorage, Ownable {
             uint256 _dailyLimit = dailyLimit(address(0)).div(factor);
             uint256 _executionMaxPerTx = executionMaxPerTx(address(0)).div(factor);
             uint256 _executionDailyLimit = executionDailyLimit(address(0)).div(factor);
+
+            // such situation can happen when calculated limits relative to the token decimals are too low
+            // e.g. minPerTx(address(0)) == 10 ** 14, _decimals == 3. _minPerTx happens to be 0, which is not allowed.
+            // in this case, limits are raised to the default values
             if (_minPerTx == 0) {
                 _minPerTx = 1;
                 if (_maxPerTx <= _minPerTx) {

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiTokenBridge.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiTokenBridge.sol
@@ -269,11 +269,11 @@ contract BasicMultiTokenBridge is EternalStorage, Ownable {
             if (_minPerTx == 0) {
                 _minPerTx = 1;
                 if (_maxPerTx <= _minPerTx) {
-                    _maxPerTx = 2;
-                    _executionMaxPerTx = 2;
+                    _maxPerTx = 100;
+                    _executionMaxPerTx = 100;
                     if (_dailyLimit <= _maxPerTx || _executionDailyLimit <= _executionMaxPerTx) {
-                        _dailyLimit = 3;
-                        _executionDailyLimit = 3;
+                        _dailyLimit = 10000;
+                        _executionDailyLimit = 10000;
                     }
                 }
             }

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeFeeManagerMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeFeeManagerMultiAMBErc20ToErc677.sol
@@ -4,13 +4,14 @@ import "./BasicMultiTokenBridge.sol";
 import "../BaseRewardAddressList.sol";
 import "../Ownable.sol";
 import "../../interfaces/ERC677.sol";
+import "../../interfaces/IBurnableMintableERC677Token.sol";
 
 /**
-* @title ForeignFeeManagerMultiAMBErc20ToErc677
+* @title HomeFeeManagerMultiAMBErc20ToErc677
 * @dev Implements the logic to distribute fees from the multi erc20 to erc677 mediator contract operations.
 * The fees are distributed in the form of native tokens to the list of reward accounts.
 */
-contract ForeignFeeManagerMultiAMBErc20ToErc677 is BaseRewardAddressList, Ownable, BasicMultiTokenBridge {
+contract HomeFeeManagerMultiAMBErc20ToErc677 is BaseRewardAddressList, Ownable, BasicMultiTokenBridge {
     using SafeMath for uint256;
 
     event FeeUpdated(bytes32 feeType, address indexed token, uint256 fee);
@@ -141,7 +142,11 @@ contract ForeignFeeManagerMultiAMBErc20ToErc677 is BaseRewardAddressList, Ownabl
                 feeToDistribute = feeToDistribute.add(diff);
             }
 
-            ERC677(_token).transfer(nextAddr, feeToDistribute);
+            if (_feeType == HOME_TO_FOREIGN_FEE) {
+                ERC677(_token).transfer(nextAddr, feeToDistribute);
+            } else {
+                IBurnableMintableERC677Token(_token).mint(nextAddr, feeToDistribute);
+            }
 
             nextAddr = getNextRewardAddress(nextAddr);
             require(nextAddr != address(0));

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/MultiTokenBridgeMediator.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/MultiTokenBridgeMediator.sol
@@ -43,9 +43,7 @@ contract MultiTokenBridgeMediator is
     * @param _recipient address that will receive the tokens
     * @param _value amount of tokens to be received
     */
-    function handleBridgedTokens(ERC677 _token, address _recipient, uint256 _value) public {
-        require(msg.sender == address(bridgeContract()));
-        require(messageSender() == mediatorContractOnOtherSide());
+    function _handleBridgedTokens(ERC677 _token, address _recipient, uint256 _value) internal {
         if (withinExecutionLimit(_token, _value)) {
             addTotalExecutedPerDay(_token, getCurrentDay(), _value);
             executeActionOnBridgedTokens(_token, _recipient, _value);
@@ -74,9 +72,7 @@ contract MultiTokenBridgeMediator is
     * It uses the information stored by passMessage method when the assets were initially transferred
     * @param _messageId id of the message which execution failed on the other network.
     */
-    function fixFailedMessage(bytes32 _messageId) external {
-        require(msg.sender == address(bridgeContract()));
-        require(messageSender() == mediatorContractOnOtherSide());
+    function fixFailedMessage(bytes32 _messageId) external onlyMediator {
         require(!messageFixed(_messageId));
 
         address token = messageToken(_messageId);

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/callflows.md
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/callflows.md
@@ -72,7 +72,7 @@ BasicHomeAMB::executeAffirmation
 ..........HomeMultiAMBErc20ToErc677::_setTokenAddressPair
 ..........BasicMultiTokenBridge::_initializeTokenBridgeLimits
 ............emit NewTokenRegistered
-..........MultiTokenBridgeMediator::handleBridgedTokens
+..........MultiTokenBridgeMediator::_handleBridgedTokens
 ............HomeMultiAMBErc20ToErc677::executeActionOnBridgedTokens
 ..............ERC677BridgeToken::mint
 ................<######>
@@ -96,7 +96,7 @@ BasicHomeAMB::executeAffirmation
 >>Mediator
 ........HomeMultiAMBErc20ToErc677::handleBridgedTokens
 ..........HomeMultiAMBErc20ToErc677::homeTokenAddress
-..........MultiTokenBridgeMediator::handleBridgedTokens
+..........MultiTokenBridgeMediator::_handleBridgedTokens
 ............HomeMultiAMBErc20ToErc677::executeActionOnBridgedTokens
 ..............ERC677BridgeToken::mint
 ................<######>
@@ -156,14 +156,15 @@ BasicForeignAMB::executeSignatures
 ........MessageProcessor::setMessageSender
 ........MessageProcessor::setMessageId
 >>Mediator
-........MultiTokenBridgeMediator::handleBridgedTokens
-..........ForeignMultiAMBErc20ToErc677::executeActionOnBridgedTokens
-............ForeignFeeManagerMultiAMBErc20ToErc677::_distributeFee
-............ForeignMultiAMBErc20ToErc677::_setMediatorBalance
+........ForeignMultiAMBErc20ToErc677::handleBridgedTokens
+..........MultiTokenBridgeMediator::_handleBridgedTokens
+............ForeignMultiAMBErc20ToErc677::executeActionOnBridgedTokens
+..............ForeignFeeManagerMultiAMBErc20ToErc677::_distributeFee
+..............ForeignMultiAMBErc20ToErc677::_setMediatorBalance
 >>Token
-..............ERC20::transfer
+................ERC20::transfer
 >>Mediator
-............emit TokensBridged
+..............emit TokensBridged
 >>Bridge
 ......MessageProcessor::setMessageCallStatus
 ......ForeignAMB::emitEventOnMessageProcessed
@@ -199,7 +200,7 @@ BasicForeignAMB::executeSignatures
 ........MessageProcessor::setMessageSender
 ........MessageProcessor::setMessageId
 >>Mediator
-........[failed MultiTokenBridgeMediator::handleBridgedTokens]
+........[failed ForeignMultiAMBErc20ToErc677::handleBridgedTokens]
 >>Bridge
 ......MessageProcessor::setMessageCallStatus
 ......MessageProcessor::setFailedMessageReceiver
@@ -269,7 +270,7 @@ BasicHomeAMB::executeAffirmation
 ........MessageProcessor::setMessageSender
 ........MessageProcessor::setMessageId
 >>Mediator
-........[failed MultiTokenBridgeMediator::handleBridgedTokens/deployAndHandleBridgedTokens]
+........[failed HomeMultiAMBErc20ToErc677::handleBridgedTokens/deployAndHandleBridgedTokens]
 >>Bridge
 ......MessageProcessor::setMessageCallStatus
 ......MessageProcessor::setFailedMessageReceiver

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1073,8 +1073,8 @@ FOREIGN_TRANSACTIONS_FEE=0.001
 HOME_MEDIATOR_REWARD_ACCOUNTS=0x
 
 # address of an already deployed PermittableToken contract that will be used as an implementation for all new created tokens
-# leave 0x, if you want to deploy a new PermittableToken for further usage
-HOME_ERC677_TOKEN_IMAGE=0x
+# leave empty, if you want to deploy a new PermittableToken for further usage
+HOME_ERC677_TOKEN_IMAGE=
 
 # The api url of an explorer to verify all the deployed contracts in Home network. Supported explorers: Blockscout, etherscan
 #HOME_EXPLORER_URL=https://blockscout.com/poa/core/api

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -408,20 +408,20 @@ if (env.BRIDGE_MODE === 'AMB_ERC_TO_NATIVE') {
 }
 
 if (env.BRIDGE_MODE === 'MULTI_AMB_ERC_TO_ERC') {
-  if (FOREIGN_REWARDABLE === 'ONE_DIRECTION') {
+  if (HOME_REWARDABLE === 'ONE_DIRECTION') {
     throw new Error(
-      `Only BOTH_DIRECTIONS is supported for collecting fees on Foreign Network on ${BRIDGE_MODE} bridge mode.`
+      `Only BOTH_DIRECTIONS is supported for collecting fees on Home Network on ${BRIDGE_MODE} bridge mode.`
     )
   }
 
-  if (HOME_REWARDABLE !== 'false') {
-    throw new Error(`Collecting fees on Home Network on ${BRIDGE_MODE} bridge mode is not supported.`)
+  if (FOREIGN_REWARDABLE !== 'false') {
+    throw new Error(`Collecting fees on Foreign Network on ${BRIDGE_MODE} bridge mode is not supported.`)
   }
 
-  if (FOREIGN_REWARDABLE === 'BOTH_DIRECTIONS') {
+  if (HOME_REWARDABLE === 'BOTH_DIRECTIONS') {
     validations = {
       ...validations,
-      FOREIGN_MEDIATOR_REWARD_ACCOUNTS: addressesValidator()
+      HOME_MEDIATOR_REWARD_ACCOUNTS: addressesValidator()
     }
   }
   validations = {

--- a/deploy/src/multi_amb_erc20_to_erc677/initializeForeign.js
+++ b/deploy/src/multi_amb_erc20_to_erc677/initializeForeign.js
@@ -21,11 +21,7 @@ const {
   FOREIGN_UPGRADEABLE_ADMIN,
   FOREIGN_AMB_BRIDGE,
   FOREIGN_MEDIATOR_REQUEST_GAS_LIMIT,
-  DEPLOYMENT_ACCOUNT_PRIVATE_KEY,
-  FOREIGN_REWARDABLE,
-  HOME_TRANSACTIONS_FEE,
-  FOREIGN_TRANSACTIONS_FEE,
-  FOREIGN_MEDIATOR_REWARD_ACCOUNTS
+  DEPLOYMENT_ACCOUNT_PRIVATE_KEY
 } = require('../loadEnv')
 
 const DEPLOYMENT_ACCOUNT_ADDRESS = privateKeyToAddress(DEPLOYMENT_ACCOUNT_PRIVATE_KEY)
@@ -41,10 +37,7 @@ async function initializeMediator({
     executionDailyLimit,
     executionMaxPerTx,
     requestGasLimit,
-    owner,
-    rewardAddressList,
-    homeToForeignFee,
-    foreignToHomeFee
+    owner
   }
 }) {
   console.log(`
@@ -56,14 +49,7 @@ async function initializeMediator({
     EXECUTION_DAILY_LIMIT : ${executionDailyLimit} which is ${Web3Utils.fromWei(executionDailyLimit)} in eth,
     EXECUTION_MAX_AMOUNT_PER_TX: ${executionMaxPerTx} which is ${Web3Utils.fromWei(executionMaxPerTx)} in eth,
     MEDIATOR_REQUEST_GAS_LIMIT : ${requestGasLimit},
-    OWNER: ${owner},
-    REWARD_ADDRESS_LIST: [${rewardAddressList.join(', ')}]`)
-  if (FOREIGN_REWARDABLE) {
-    console.log(`
-    HOME_TO_FOREIGN_FEE: ${homeToForeignFee} which is ${HOME_TRANSACTIONS_FEE * 100}%
-    FOREIGN_TO_HOME_FEE: ${foreignToHomeFee} which is ${FOREIGN_TRANSACTIONS_FEE * 100}% 
-    `)
-  }
+    OWNER: ${owner}`)
 
   return contract.methods
     .initialize(
@@ -72,9 +58,7 @@ async function initializeMediator({
       [dailyLimit.toString(), maxPerTx.toString(), minPerTx.toString()],
       [executionDailyLimit.toString(), executionMaxPerTx.toString()],
       requestGasLimit,
-      owner,
-      rewardAddressList,
-      [homeToForeignFee.toString(), foreignToHomeFee.toString()]
+      owner
     )
     .encodeABI()
 }
@@ -84,13 +68,6 @@ async function initialize({ homeBridge, foreignBridge }) {
   const contract = new web3Home.eth.Contract(ForeignBridge.abi, foreignBridge)
 
   console.log('\n[Foreign] Initializing Bridge Mediator with following parameters:')
-  let homeFeeInWei = '0'
-  let foreignFeeInWei = '0'
-  if (FOREIGN_REWARDABLE) {
-    homeFeeInWei = Web3Utils.toWei(HOME_TRANSACTIONS_FEE.toString(), 'ether')
-    foreignFeeInWei = Web3Utils.toWei(FOREIGN_TRANSACTIONS_FEE.toString(), 'ether')
-  }
-  const rewardList = FOREIGN_MEDIATOR_REWARD_ACCOUNTS.split(' ')
 
   const initializeData = await initializeMediator({
     contract,
@@ -104,9 +81,6 @@ async function initialize({ homeBridge, foreignBridge }) {
       minPerTx: FOREIGN_MIN_AMOUNT_PER_TX,
       executionDailyLimit: HOME_DAILY_LIMIT,
       executionMaxPerTx: HOME_MAX_AMOUNT_PER_TX,
-      rewardAddressList: rewardList,
-      homeToForeignFee: homeFeeInWei,
-      foreignToHomeFee: foreignFeeInWei
     }
   })
 

--- a/test/multi_amb_erc20_to_erc677/home_mediator.test.js
+++ b/test/multi_amb_erc20_to_erc677/home_mediator.test.js
@@ -458,11 +458,11 @@ contract('HomeMultiAMBErc20ToErc677', async accounts => {
         token = await bridgeToken(token, '1')
 
         expect(await token.decimals()).to.be.bignumber.equal('0')
-        expect(await contract.dailyLimit(token.address)).to.be.bignumber.equal('3')
-        expect(await contract.maxPerTx(token.address)).to.be.bignumber.equal('2')
+        expect(await contract.dailyLimit(token.address)).to.be.bignumber.equal('10000')
+        expect(await contract.maxPerTx(token.address)).to.be.bignumber.equal('100')
         expect(await contract.minPerTx(token.address)).to.be.bignumber.equal('1')
-        expect(await contract.executionDailyLimit(token.address)).to.be.bignumber.equal('3')
-        expect(await contract.executionMaxPerTx(token.address)).to.be.bignumber.equal('2')
+        expect(await contract.executionDailyLimit(token.address)).to.be.bignumber.equal('10000')
+        expect(await contract.executionMaxPerTx(token.address)).to.be.bignumber.equal('100')
       })
 
       it('should initialize fees', async () => {


### PR DESCRIPTION
After an additional discussion, it was decided to move fee manager functionality into the `HomeMultiAMBErc20ToErc677` mediator. Updated contracts bytecode size:
* **Home**: `22.7 kb`
* **Foreign**: `16.3 kb`
