### PR TITLE
Increase the version of AMB multi-token extension to 1.0.2

### DIFF
--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
@@ -71,7 +71,7 @@ contract BasicMultiAMBErc20ToErc677 is
     * @return patch value of the version
     */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 0, 1);
+        return (1, 0, 2);
     }
 
     /**


### PR DESCRIPTION
Although the modifications of the AMB multi-token extension contracts were made under #466, they were not reflected in the version of the extension.