### PR TITLE
Extra check for balance increase

### DIFF
--- a/contracts/libraries/SafeERC20.sol
+++ b/contracts/libraries/SafeERC20.sol
@@ -1,0 +1,37 @@
+pragma solidity 0.4.24;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../interfaces/ERC677.sol";
+
+/**
+ * @title SafeERC20
+ * @dev Helper methods for safe token transfers.
+ * Functions perform additional checks to be sure that token transfer really happened.
+ */
+library SafeERC20 {
+    using SafeMath for uint256;
+
+    /**
+    * @dev Same as ERC20.transfer(address,uint256) but with extra consistency checks.
+    * @param _token address of the token contract
+    * @param _to address of the receiver
+    * @param _value amount of tokens to send
+    */
+    function safeTransfer(address _token, address _to, uint256 _value) internal {
+        uint256 balance = ERC677(_token).balanceOf(address(this));
+        LegacyERC20(_token).transfer(_to, _value);
+        require(balance.sub(_value) == ERC677(_token).balanceOf(address(this)));
+    }
+
+    /**
+    * @dev Same as ERC20.transferFrom(address,address,uint256) but with extra consistency checks.
+    * @param _token address of the token contract
+    * @param _from address of the sender
+    * @param _value amount of tokens to send
+    */
+    function safeTransferFrom(address _token, address _from, uint256 _value) internal {
+        uint256 balance = ERC677(_token).balanceOf(address(this));
+        LegacyERC20(_token).transferFrom(_from, address(this), _value);
+        require(balance.add(_value) == ERC677(_token).balanceOf(address(this)));
+    }
+}

--- a/contracts/libraries/SafeERC20.sol
+++ b/contracts/libraries/SafeERC20.sol
@@ -20,6 +20,14 @@ library SafeERC20 {
     function safeTransfer(address _token, address _to, uint256 _value) internal {
         uint256 balance = ERC677(_token).balanceOf(address(this));
         LegacyERC20(_token).transfer(_to, _value);
+        assembly {
+            if returndatasize {
+                returndatacopy(0, 0, 32)
+                if iszero(mload(0)) {
+                    revert(0, 0)
+                }
+            }
+        }
         require(balance.sub(_value) == ERC677(_token).balanceOf(address(this)));
     }
 
@@ -32,6 +40,14 @@ library SafeERC20 {
     function safeTransferFrom(address _token, address _from, uint256 _value) internal {
         uint256 balance = ERC677(_token).balanceOf(address(this));
         LegacyERC20(_token).transferFrom(_from, address(this), _value);
+        assembly {
+            if returndatasize {
+                returndatacopy(0, 0, 32)
+                if iszero(mload(0)) {
+                    revert(0, 0)
+                }
+            }
+        }
         require(balance.add(_value) == ERC677(_token).balanceOf(address(this)));
     }
 }

--- a/contracts/libraries/SafeERC20.sol
+++ b/contracts/libraries/SafeERC20.sol
@@ -18,7 +18,6 @@ library SafeERC20 {
     * @param _value amount of tokens to send
     */
     function safeTransfer(address _token, address _to, uint256 _value) internal {
-        uint256 balance = ERC677(_token).balanceOf(address(this));
         LegacyERC20(_token).transfer(_to, _value);
         assembly {
             if returndatasize {
@@ -28,7 +27,6 @@ library SafeERC20 {
                 }
             }
         }
-        require(balance.sub(_value) == ERC677(_token).balanceOf(address(this)));
     }
 
     /**
@@ -38,7 +36,6 @@ library SafeERC20 {
     * @param _value amount of tokens to send
     */
     function safeTransferFrom(address _token, address _from, uint256 _value) internal {
-        uint256 balance = ERC677(_token).balanceOf(address(this));
         LegacyERC20(_token).transferFrom(_from, address(this), _value);
         assembly {
             if returndatasize {
@@ -48,6 +45,5 @@ library SafeERC20 {
                 }
             }
         }
-        require(balance.add(_value) == ERC677(_token).balanceOf(address(this)));
     }
 }

--- a/contracts/upgradeable_contracts/amb_erc20_to_native/BasicAMBErc20ToNative.sol
+++ b/contracts/upgradeable_contracts/amb_erc20_to_native/BasicAMBErc20ToNative.sol
@@ -51,7 +51,7 @@ contract BasicAMBErc20ToNative is Initializable, Upgradeable, Claimable, Version
     * @return patch value of the version
     */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 1, 0);
+        return (1, 1, 1);
     }
 
     /**

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -62,6 +62,12 @@ contract BasicAMBErc677ToErc677 is
         return mediatorContractOnOtherSide();
     }
 
+    /**
+    * @dev Initiates the bridge operation that will lock the amount of tokens transferred and mint the tokens on
+    * the other network. The user should first call Approve method of the ERC677 token.
+    * @param _receiver address that will receive the minted tokens on the other network.
+    * @param _value amount of tokens to be transferred to the other network.
+    */
     function relayTokens(address _receiver, uint256 _value) external {
         // This lock is to prevent calling passMessage twice if a ERC677 token is used.
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
@@ -90,7 +96,7 @@ contract BasicAMBErc677ToErc677 is
     }
 
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 2, 0);
+        return (1, 2, 1);
     }
 
     function getBridgeMode() external pure returns (bytes4 _data) {

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/ForeignAMBErc677ToErc677.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.4.24;
 
 import "./BasicAMBErc677ToErc677.sol";
+import "../../libraries/SafeERC20.sol";
 
 /**
 * @title ForeignAMBErc677ToErc677
@@ -8,6 +9,8 @@ import "./BasicAMBErc677ToErc677.sol";
 * It is designed to be used as an implementation contract of EternalStorageProxy contract.
 */
 contract ForeignAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
+    using SafeERC20 for ERC677;
+
     /**
      * @dev Executes action on the request to withdraw tokens relayed from the other network
      * @param _recipient address of tokens receiver
@@ -16,8 +19,29 @@ contract ForeignAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
     function executeActionOnBridgedTokens(address _recipient, uint256 _value) internal {
         uint256 value = _unshiftValue(_value);
         bytes32 _messageId = messageId();
-        erc677token().transfer(_recipient, value);
+        erc677token().safeTransfer(_recipient, value);
         emit TokensBridged(_recipient, value, _messageId);
+    }
+
+    /**
+    * @dev Initiates the bridge operation that will lock the amount of tokens transferred and mint the tokens on
+    * the other network. The user should first call Approve method of the ERC677 token.
+    * @param _receiver address that will receive the minted tokens on the other network.
+    * @param _value amount of tokens to be transferred to the other network.
+    */
+    function relayTokens(address _receiver, uint256 _value) external {
+        // This lock is to prevent calling passMessage twice if a ERC677 token is used.
+        // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
+        // which will call passMessage.
+        require(!lock());
+        ERC677 token = erc677token();
+        require(withinLimit(_value));
+        addTotalSpentPerDay(getCurrentDay(), _value);
+
+        setLock(true);
+        token.safeTransferFrom(msg.sender, _value);
+        setLock(false);
+        bridgeSpecificActionsOnTokenTransfer(token, msg.sender, _value, abi.encodePacked(_receiver));
     }
 
     /**
@@ -38,6 +62,6 @@ contract ForeignAMBErc677ToErc677 is BasicAMBErc677ToErc677 {
     }
 
     function executeActionOnFixedTokens(address _recipient, uint256 _value) internal {
-        erc677token().transfer(_recipient, _value);
+        erc677token().safeTransfer(_recipient, _value);
     }
 }

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
@@ -58,7 +58,7 @@ contract BasicMultiAMBErc20ToErc677 is
     * @return patch value of the version
     */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 1, 0);
+        return (1, 1, 1);
     }
 
     /**

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
@@ -100,7 +100,9 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
         address to = address(this);
 
         setLock(true);
+        uint256 balance = token.balanceOf(to);
         LegacyERC20(token).transferFrom(msg.sender, to, _value);
+        require(token.balanceOf(to) == balance.add(_value));
         setLock(false);
         bridgeSpecificActionsOnTokenTransfer(token, msg.sender, _value, abi.encodePacked(_receiver));
     }

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
@@ -53,7 +53,9 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
      */
     function executeActionOnBridgedTokens(address _token, address _recipient, uint256 _value) internal {
         bytes32 _messageId = messageId();
+        uint256 balance = ERC677(_token).balanceOf(address(this));
         LegacyERC20(_token).transfer(_recipient, _value);
+        require(ERC677(_token).balanceOf(address(this)) == balance.sub(_value));
         _setMediatorBalance(_token, mediatorBalance(_token).sub(_value));
         emit TokensBridged(_token, _recipient, _value, _messageId);
     }
@@ -191,7 +193,9 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
     */
     function executeActionOnFixedTokens(address _token, address _recipient, uint256 _value) internal {
         _setMediatorBalance(_token, mediatorBalance(_token).sub(_value));
+        uint256 balance = ERC677(_token).balanceOf(address(this));
         LegacyERC20(_token).transfer(_recipient, _value);
+        require(ERC677(_token).balanceOf(address(this)) == balance.sub(_value));
     }
 
     /**

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
@@ -4,6 +4,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
 import "./BasicMultiAMBErc20ToErc677.sol";
 import "./HomeMultiAMBErc20ToErc677.sol";
 import "../../libraries/TokenReader.sol";
+import "../../libraries/SafeERC20.sol";
 
 /**
  * @title ForeignMultiAMBErc20ToErc677
@@ -11,6 +12,9 @@ import "../../libraries/TokenReader.sol";
  * It is designed to be used as an implementation contract of EternalStorageProxy contract.
  */
 contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
+    using SafeERC20 for address;
+    using SafeERC20 for ERC677;
+
     /**
     * @dev Stores the initial parameters of the mediator.
     * @param _bridgeContract the address of the AMB bridge contract.
@@ -53,9 +57,7 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
      */
     function executeActionOnBridgedTokens(address _token, address _recipient, uint256 _value) internal {
         bytes32 _messageId = messageId();
-        uint256 balance = ERC677(_token).balanceOf(address(this));
-        LegacyERC20(_token).transfer(_recipient, _value);
-        require(ERC677(_token).balanceOf(address(this)) == balance.sub(_value));
+        _token.safeTransfer(_recipient, _value);
         _setMediatorBalance(_token, mediatorBalance(_token).sub(_value));
         emit TokensBridged(_token, _recipient, _value, _messageId);
     }
@@ -99,12 +101,9 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
         // which will call passMessage.
         require(!lock());
-        address to = address(this);
 
         setLock(true);
-        uint256 balance = token.balanceOf(to);
-        LegacyERC20(token).transferFrom(msg.sender, to, _value);
-        require(token.balanceOf(to) == balance.add(_value));
+        token.safeTransferFrom(msg.sender, _value);
         setLock(false);
         bridgeSpecificActionsOnTokenTransfer(token, msg.sender, _value, abi.encodePacked(_receiver));
     }
@@ -193,9 +192,7 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
     */
     function executeActionOnFixedTokens(address _token, address _recipient, uint256 _value) internal {
         _setMediatorBalance(_token, mediatorBalance(_token).sub(_value));
-        uint256 balance = ERC677(_token).balanceOf(address(this));
-        LegacyERC20(_token).transfer(_recipient, _value);
-        require(ERC677(_token).balanceOf(address(this)) == balance.sub(_value));
+        _token.safeTransfer(_recipient, _value);
     }
 
     /**


### PR DESCRIPTION
The proposed fix is to address the issue with tokens that does not revert for `transferFrom` and `transfer` calls and return `false` instead.
It is not possible to apply the approach suggested in https://github.com/OpenZeppelin/openzeppelin-contracts/blob/0b489f4d79544ab9b870abe121077043feb971b8/contracts/token/ERC20/SafeERC20.sol#L64 due to significant rework required to switch to newer version of Solidity. Later it will be investigated a possibility to implement it in form of assembly.