### PR TITLE
Bump package version to 5.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This version contains the fix for AMB mediators to properly work with some non-standard ERC20 tokens and the changes for GitHub actions to publish flatten scripts