### PR TITLE
Add extra check on internal call gaslimit

### DIFF
--- a/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
@@ -198,9 +198,11 @@ contract MessageProcessor is EternalStorage {
         // After EIP-150, max gas cost allowed to be passed to the internal call is equal to the 63/64 of total gas left.
         // In reallity, min(gasLimit, 63/64 * gasleft()) will be used as the call gas limit.
         // Imagine a situation, when message requires 10000000 gas to be executed successfully.
-        // Also suppose, that at this point, gasleft() is equal to 10158000, so the callee will receiver ~ 10158000 * 63 / 64 = 9999300 gas.
-        // That amount of gas is not enough, so the call will fail.
-        // Now the caller has ~ 158000 gas to finish its execution which is quite enough.
+        // Also suppose, that at this point, gasleft() is equal to 10158000, so the callee will receive ~ 10158000 * 63 / 64 = 9999300 gas.
+        // That amount of gas is not enough, so the call will fail. At the same time,
+        // even if the callee failed the bridge contract still has ~ 158000 gas to
+        // finish its execution and it will be enough. The internal call fails but
+        // only because the oracle provides incorrect gas limit for the transaction
         // This check is needed here in order to force contract to pass exactly the requested amount of gas.
         // Avoiding it may leed to the unwanted message failure in some extreme cases.
         require((gasleft() * 63) / 64 > _gas);

--- a/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
@@ -194,6 +194,17 @@ contract MessageProcessor is EternalStorage {
         setMessageSender(_sender);
         setMessageId(_messageId);
         setMessageSourceChainId(_sourceChainId);
+
+        // After EIP-150, max gas cost allowed to be passed to the internal call is equal to the 63/64 of total gas left.
+        // In reallity, min(gasLimit, 63/64 * gasleft()) will be used as the call gas limit.
+        // Imagine a situation, when message requires 10000000 gas to be executed successfully.
+        // Also suppose, that at this point, gasleft() is equal to 10158000, so the callee will receiver ~ 10158000 * 63 / 64 = 9999300 gas.
+        // That amount of gas is not enough, so the call will fail.
+        // Now the caller has ~ 158000 gas to finish its execution which is quite enough.
+        // This check is needed here in order to force contract to pass exactly the requested amount of gas.
+        // Avoiding it may leed to the unwanted message failure in some extreme cases.
+        require((gasleft() * 63) / 64 > _gas);
+
         bool status = _contract.call.gas(_gas)(_data);
         setMessageSender(address(0));
         setMessageId(bytes32(0));


### PR DESCRIPTION
A possible gas limit issue was identified in the AMB bridge contracts. Issue is related to the 63/64 rule for gas limit, introduced in the [EIP-150](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md). Please take a look at the commit diff for more information.

Bridge validator responsible for message delivery can intentionally or unintentionally use a raw value of `eth_estimateGas`, leading to the unexpected message failure with OOG error.

Such an issue can be only exploited when `maxGasPerTx()` in the contract is high enough (e. g. > `5000000`), so that 1/64 of this value will be enough to finish the function execution (at least 3 SSTORE (20000 gas) + 3 SSTORE (5000 gas)).