### PR TITLE
Add missing zero address checks

### DIFF
--- a/contracts/upgradeable_contracts/BridgeValidators.sol
+++ b/contracts/upgradeable_contracts/BridgeValidators.sol
@@ -9,8 +9,7 @@ contract BridgeValidators is BaseBridgeValidators {
         returns (bool)
     {
         require(!isInitialized());
-        require(_owner != address(0));
-        setOwner(_owner);
+        _setOwner(_owner);
         require(_requiredSignatures != 0);
         require(_initialValidators.length >= _requiredSignatures);
 

--- a/contracts/upgradeable_contracts/OtherSideBridgeStorage.sol
+++ b/contracts/upgradeable_contracts/OtherSideBridgeStorage.sol
@@ -6,6 +6,7 @@ contract OtherSideBridgeStorage is EternalStorage {
     bytes32 internal constant BRIDGE_CONTRACT = 0x71483949fe7a14d16644d63320f24d10cf1d60abecc30cc677a340e82b699dd2; // keccak256(abi.encodePacked("bridgeOnOtherSide"))
 
     function _setBridgeContractOnOtherSide(address _bridgeContract) internal {
+        require(_bridgeContract != address(0));
         addressStorage[BRIDGE_CONTRACT] = _bridgeContract;
     }
 

--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -55,14 +55,14 @@ contract Ownable is EternalStorage {
     * @param newOwner the address to transfer ownership to.
     */
     function transferOwnership(address newOwner) external onlyOwner {
-        require(newOwner != address(0));
-        setOwner(newOwner);
+        _setOwner(newOwner);
     }
 
     /**
     * @dev Sets a new owner address
     */
-    function setOwner(address newOwner) internal {
+    function _setOwner(address newOwner) internal {
+        require(newOwner != address(0));
         emit OwnershipTransferred(owner(), newOwner);
         addressStorage[OWNER] = newOwner;
     }

--- a/contracts/upgradeable_contracts/RewardableValidators.sol
+++ b/contracts/upgradeable_contracts/RewardableValidators.sol
@@ -10,8 +10,7 @@ contract RewardableValidators is BaseBridgeValidators {
         address _owner
     ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
-        require(_owner != address(0));
-        setOwner(_owner);
+        _setOwner(_owner);
         require(_requiredSignatures != 0);
         require(_initialValidators.length >= _requiredSignatures);
         require(_initialValidators.length == _initialRewards.length);

--- a/contracts/upgradeable_contracts/amb_erc20_to_native/BasicAMBErc20ToNative.sol
+++ b/contracts/upgradeable_contracts/amb_erc20_to_native/BasicAMBErc20ToNative.sol
@@ -33,7 +33,6 @@ contract BasicAMBErc20ToNative is Initializable, Upgradeable, Claimable, Version
         address _owner
     ) internal {
         require(!isInitialized());
-        require(_owner != address(0));
 
         _setBridgeContract(_bridgeContract);
         _setMediatorContractOnOtherSide(_mediatorContract);
@@ -41,7 +40,7 @@ contract BasicAMBErc20ToNative is Initializable, Upgradeable, Claimable, Version
         _setLimits(_dailyLimitMaxPerTxMinPerTxArray);
         _setExecutionLimits(_executionDailyLimitExecutionMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
     }
 
     /**

--- a/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
+++ b/contracts/upgradeable_contracts/amb_erc677_to_erc677/BasicAMBErc677ToErc677.sol
@@ -44,7 +44,7 @@ contract BasicAMBErc677ToErc677 is
         _setExecutionLimits(_executionDailyLimitExecutionMaxPerTxArray);
         _setRequestGasLimit(_requestGasLimit);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
         setInitialize();
 
         return isInitialized();

--- a/contracts/upgradeable_contracts/amb_native_to_erc20/BasicAMBNativeToErc20.sol
+++ b/contracts/upgradeable_contracts/amb_native_to_erc20/BasicAMBNativeToErc20.sol
@@ -43,7 +43,6 @@ contract BasicAMBNativeToErc20 is
         address _feeManager
     ) internal {
         require(!isInitialized());
-        require(_owner != address(0));
 
         _setBridgeContract(_bridgeContract);
         _setMediatorContractOnOtherSide(_mediatorContract);
@@ -52,7 +51,7 @@ contract BasicAMBNativeToErc20 is
         _setExecutionLimits(_executionDailyLimitExecutionMaxPerTxArray);
         _setDecimalShift(_decimalShift);
         _setFeeManagerContract(_feeManager);
-        setOwner(_owner);
+        _setOwner(_owner);
     }
 
     /**

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicAMB.sol
@@ -39,7 +39,7 @@ contract BasicAMB is BasicBridge, VersionableAMB {
         uintStorage[MAX_GAS_PER_TX] = _maxGasPerTx;
         _setGasPrice(_gasPrice);
         _setRequiredBlockConfirmations(_requiredBlockConfirmations);
-        setOwner(_owner);
+        _setOwner(_owner);
         setInitialize();
 
         return isInitialized();

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -16,7 +16,6 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_owner != address(0));
 
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc20token(_erc20token);
@@ -26,7 +25,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
         _setLimits(_dailyLimitMaxPerTxMinPerTxArray);
         _setExecutionLimits(_homeDailyLimitHomeMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
         setInitialize();
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -109,7 +109,7 @@ contract HomeBridgeErcToErc is
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_owner != address(0));
+
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
         _setLimits(_dailyLimitMaxPerTxMinPerTxArray);
@@ -117,7 +117,7 @@ contract HomeBridgeErcToErc is
         _setRequiredBlockConfirmations(_requiredBlockConfirmations);
         _setExecutionLimits(_foreignDailyLimitForeignMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
         setErc677token(_erc677token);
     }
 

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -19,8 +19,6 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
     ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_owner != address(0));
-        require(_bridgeOnOtherSide != address(0));
 
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc20token(_erc20token);
@@ -30,7 +28,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge, OtherSideB
         _setLimits(_dailyLimitMaxPerTxMinPerTxArray);
         _setExecutionLimits(_homeDailyLimitHomeMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
         _setBridgeContractOnOtherSide(_bridgeOnOtherSide);
         setInitialize();
 

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -132,7 +132,6 @@ contract HomeBridgeErcToNative is
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
         require(_blockReward == address(0) || AddressUtils.isContract(_blockReward));
-        require(_owner != address(0));
 
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
@@ -142,7 +141,7 @@ contract HomeBridgeErcToNative is
         addressStorage[BLOCK_REWARD_CONTRACT] = _blockReward;
         _setExecutionLimits(_foreignDailyLimitForeignMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
     }
 
     function onExecuteAffirmation(address _recipient, uint256 _value, bytes32 txHash) internal returns (bool) {

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
@@ -35,14 +35,13 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
         address _owner
     ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
-        require(_owner != address(0));
 
         _setBridgeContract(_bridgeContract);
         _setMediatorContractOnOtherSide(_mediatorContract);
         _setLimits(address(0), _dailyLimitMaxPerTxMinPerTxArray);
         _setExecutionLimits(address(0), _executionDailyLimitExecutionMaxPerTxArray);
         _setRequestGasLimit(_requestGasLimit);
-        setOwner(_owner);
+        _setOwner(_owner);
 
         setInitialize();
 

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeMultiAMBErc20ToErc677.sol
@@ -42,14 +42,13 @@ contract HomeMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677, HomeFeeManager
         uint256[2] _fees // [ 0 = homeToForeignFee, 1 = foreignToHomeFee ]
     ) external onlyRelevantSender returns (bool) {
         require(!isInitialized());
-        require(_owner != address(0));
 
         _setBridgeContract(_bridgeContract);
         _setMediatorContractOnOtherSide(_mediatorContract);
         _setLimits(address(0), _dailyLimitMaxPerTxMinPerTxArray);
         _setExecutionLimits(address(0), _executionDailyLimitExecutionMaxPerTxArray);
         _setRequestGasLimit(_requestGasLimit);
-        setOwner(_owner);
+        _setOwner(_owner);
         _setTokenImage(_tokenImage);
         if (_rewardAddreses.length > 0) {
             _setRewardAddressList(_rewardAddreses);

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -89,7 +89,6 @@ contract ForeignBridgeNativeToErc is
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_owner != address(0));
 
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         setErc677token(_erc677token);
@@ -99,7 +98,7 @@ contract ForeignBridgeNativeToErc is
         _setRequiredBlockConfirmations(_requiredBlockConfirmations);
         _setExecutionLimits(_homeDailyLimitHomeMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
         _setBridgeContractOnOtherSide(_bridgeOnOtherSide);
     }
 

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -94,7 +94,6 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_owner != address(0));
 
         addressStorage[VALIDATOR_CONTRACT] = _validatorContract;
         uintStorage[DEPLOYED_AT_BLOCK] = block.number;
@@ -103,7 +102,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         _setRequiredBlockConfirmations(_requiredBlockConfirmations);
         _setExecutionLimits(_foreignDailyLimitForeignMaxPerTxArray);
         _setDecimalShift(_decimalShift);
-        setOwner(_owner);
+        _setOwner(_owner);
     }
 
     function onSignaturesCollected(bytes _message) internal {

--- a/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
+++ b/test/amb_erc677_to_erc677/AMBErc677ToErc677Behavior.test.js
@@ -144,6 +144,18 @@ function shouldBehaveLikeBasicAMBErc677ToErc677(otherSideMediatorContract, accou
         owner
       ).should.be.rejected
 
+      // not valid owner
+      await contract.initialize(
+        bridgeContract.address,
+        mediatorContract.address,
+        erc677Token.address,
+        [dailyLimit, maxPerTx, minPerTx],
+        [executionDailyLimit, executionMaxPerTx],
+        maxGasPerTx,
+        decimalShiftZero,
+        ZERO_ADDRESS
+      ).should.be.rejected
+
       const { logs } = await contract.initialize(
         bridgeContract.address,
         mediatorContract.address,

--- a/test/arbitrary_message/foreign_bridge.test.js
+++ b/test/arbitrary_message/foreign_bridge.test.js
@@ -150,6 +150,17 @@ contract('ForeignAMB', async accounts => {
       await foreignBridge
         .initialize(FOREIGN_CHAIN_ID_HEX, HOME_CHAIN_ID_HEX, validatorContract.address, oneEther, gasPrice, 0, owner)
         .should.be.rejectedWith(ERROR_MSG)
+      await foreignBridge
+        .initialize(
+          FOREIGN_CHAIN_ID_HEX,
+          HOME_CHAIN_ID_HEX,
+          validatorContract.address,
+          oneEther,
+          gasPrice,
+          requiredBlockConfirmations,
+          ZERO_ADDRESS
+        )
+        .should.be.rejectedWith(ERROR_MSG)
       await foreignBridge.initialize(
         FOREIGN_CHAIN_ID_HEX,
         HOME_CHAIN_ID_HEX,

--- a/test/arbitrary_message/home_bridge.test.js
+++ b/test/arbitrary_message/home_bridge.test.js
@@ -130,6 +130,17 @@ contract('HomeAMB', async accounts => {
       await homeBridge
         .initialize(HOME_CHAIN_ID_HEX, FOREIGN_CHAIN_ID_HEX, validatorContract.address, oneEther, gasPrice, 0, owner)
         .should.be.rejectedWith(ERROR_MSG)
+      await homeBridge
+        .initialize(
+          HOME_CHAIN_ID_HEX,
+          FOREIGN_CHAIN_ID_HEX,
+          validatorContract.address,
+          oneEther,
+          0,
+          requiredBlockConfirmations,
+          ZERO_ADDRESS
+        )
+        .should.be.rejectedWith(ERROR_MSG)
       await homeBridge.initialize(
         HOME_CHAIN_ID_HEX,
         FOREIGN_CHAIN_ID_HEX,

--- a/test/native_to_erc/foreign_bridge_test.js
+++ b/test/native_to_erc/foreign_bridge_test.js
@@ -155,6 +155,19 @@ contract('ForeignBridge', async accounts => {
         otherSideBridgeAddress
       ).should.be.rejected
 
+      // not valid otherSideBridgeAddress
+      await foreignBridge.initialize(
+        validatorContract.address,
+        token.address,
+        [oneEther, halfEther, minPerTx],
+        gasPrice,
+        requireBlockConfirmations,
+        [homeDailyLimit, homeMaxPerTx],
+        owner,
+        '9',
+        ZERO_ADDRESS
+      ).should.be.rejected
+
       const { logs } = await foreignBridge.initialize(
         validatorContract.address,
         token.address,


### PR DESCRIPTION
Some of the checks like `require(_owner != address(0))` were missing in a couple of contracts. This PR adds them where needed.