### PR TITLE
Optimize Omnibridge gas usage

### DIFF
--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
@@ -88,5 +88,6 @@ contract BasicMultiAMBErc20ToErc677 is
     function _relayTokens(ERC677 token, address _receiver, uint256 _value) internal;
 
     /* solcov ignore next */
-    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, uint256 _value, bytes _data) internal;
+    function bridgeSpecificActionsOnTokenTransfer(ERC677 _token, address _from, address _receiver, uint256 _value)
+        internal;
 }

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
@@ -99,6 +99,8 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
         // This lock is to prevent calling passMessage twice if a ERC677 token is used.
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
         // which will call passMessage.
+        require(!lock());
+
         setLock(true);
         token.safeTransferFrom(msg.sender, _value);
         setLock(false);

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/ForeignMultiAMBErc20ToErc677.sol
@@ -99,8 +99,6 @@ contract ForeignMultiAMBErc20ToErc677 is BasicMultiAMBErc20ToErc677 {
         // This lock is to prevent calling passMessage twice if a ERC677 token is used.
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
         // which will call passMessage.
-        require(!lock());
-
         setLock(true);
         token.safeTransferFrom(msg.sender, _value);
         setLock(false);

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeMultiAMBErc20ToErc677.sol
@@ -165,7 +165,6 @@ contract HomeMultiAMBErc20ToErc677 is
         // This lock is to prevent calling passMessage twice if a ERC677 token is used.
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
         // which will call passMessage.
-        require(!lock());
         address to = address(this);
         // if msg.sender if not a valid token contract, this check will fail, since limits are zeros
         // so the following check is not needed

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/HomeMultiAMBErc20ToErc677.sol
@@ -165,6 +165,7 @@ contract HomeMultiAMBErc20ToErc677 is
         // This lock is to prevent calling passMessage twice if a ERC677 token is used.
         // When transferFrom is called, after the transfer, the ERC677 token will call onTokenTransfer from this contract
         // which will call passMessage.
+        require(!lock());
         address to = address(this);
         // if msg.sender if not a valid token contract, this check will fail, since limits are zeros
         // so the following check is not needed


### PR DESCRIPTION
This PR slightly reduces the gas usage for `bridgeSpecificActionsOnTokenTransfer` function in the MultiToken extension.

The following actions were performed:
* Remove unnecessary `abi.encodePacked(...)` call when dealing with `relayTokens` functionality.
* ~~Remove redundant `require(!lock());` check in `_relayTokens`, since the temporary lock variable cannot be set to `true` in the beginning of the `relayTokens` call.~~
* Remove redundant `lock()` check in `bridgeSpecificActionsOnTokenTransfer`, since the check was either already done previously in the code (in `onTokenTransfer`), or the lock was explicitly disabled by the call to `setLock(false)` (in `_relayTokens`).