### PR TITLE
Optimize use of temporary variables passed through storage

### DIFF
--- a/contracts/upgradeable_contracts/ReentrancyGuard.sol
+++ b/contracts/upgradeable_contracts/ReentrancyGuard.sol
@@ -3,13 +3,17 @@ pragma solidity 0.4.24;
 import "../upgradeability/EternalStorage.sol";
 
 contract ReentrancyGuard is EternalStorage {
-    bytes32 internal constant LOCK = 0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92; // keccak256(abi.encodePacked("lock"))
-
-    function lock() internal returns (bool) {
-        return boolStorage[LOCK];
+    function lock() internal returns (bool res) {
+        assembly {
+            // keccak256(abi.encodePacked("lock"))
+            res := sload(0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92)
+        }
     }
 
     function setLock(bool _lock) internal {
-        boolStorage[LOCK] = _lock;
+        assembly {
+            // keccak256(abi.encodePacked("lock"))
+            sstore(0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92, _lock)
+        }
     }
 }

--- a/contracts/upgradeable_contracts/ReentrancyGuard.sol
+++ b/contracts/upgradeable_contracts/ReentrancyGuard.sol
@@ -1,8 +1,6 @@
 pragma solidity 0.4.24;
 
-import "../upgradeability/EternalStorage.sol";
-
-contract ReentrancyGuard is EternalStorage {
+contract ReentrancyGuard {
     function lock() internal returns (bool res) {
         assembly {
             // keccak256(abi.encodePacked("lock"))

--- a/contracts/upgradeable_contracts/ReentrancyGuard.sol
+++ b/contracts/upgradeable_contracts/ReentrancyGuard.sol
@@ -3,15 +3,19 @@ pragma solidity 0.4.24;
 contract ReentrancyGuard {
     function lock() internal returns (bool res) {
         assembly {
-            // keccak256(abi.encodePacked("lock"))
-            res := sload(0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92)
+            // Even though this is not the same as boolStorage[keccak256(abi.encodePacked("lock"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            res := sload(0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92) // keccak256(abi.encodePacked("lock"))
         }
     }
 
     function setLock(bool _lock) internal {
         assembly {
-            // keccak256(abi.encodePacked("lock"))
-            sstore(0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92, _lock)
+            // Even though this is not the same as boolStorage[keccak256(abi.encodePacked("lock"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            sstore(0x6168652c307c1e813ca11cfb3a601f1cf3b22452021a5052d8b05f1f1f8a3e92, _lock) // keccak256(abi.encodePacked("lock"))
         }
     }
 }

--- a/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/MessageProcessor.sol
@@ -87,8 +87,10 @@ contract MessageProcessor is EternalStorage {
     */
     function messageSender() external view returns (address sender) {
         assembly {
-            // keccak256(abi.encodePacked("messageSender"))
-            sender := sload(0x7b58b2a669d8e0992eae9eaef641092c0f686fd31070e7236865557fa1571b5b)
+            // Even though this is not the same as addressStorage[keccak256(abi.encodePacked("messageSender"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            sender := sload(0x7b58b2a669d8e0992eae9eaef641092c0f686fd31070e7236865557fa1571b5b) // keccak256(abi.encodePacked("messageSender"))
         }
     }
 
@@ -98,8 +100,10 @@ contract MessageProcessor is EternalStorage {
     */
     function setMessageSender(address _sender) internal {
         assembly {
-            // keccak256(abi.encodePacked("messageSender"))
-            sstore(0x7b58b2a669d8e0992eae9eaef641092c0f686fd31070e7236865557fa1571b5b, _sender)
+            // Even though this is not the same as addressStorage[keccak256(abi.encodePacked("messageSender"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            sstore(0x7b58b2a669d8e0992eae9eaef641092c0f686fd31070e7236865557fa1571b5b, _sender) // keccak256(abi.encodePacked("messageSender"))
         }
     }
 
@@ -109,8 +113,10 @@ contract MessageProcessor is EternalStorage {
     */
     function messageId() public view returns (bytes32 id) {
         assembly {
-            // keccak256(abi.encodePacked("messageId"))
-            id := sload(0xe34bb2103dc34f2c144cc216c132d6ffb55dac57575c22e089161bbe65083304)
+            // Even though this is not the same as uintStorage[keccak256(abi.encodePacked("messageId"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            id := sload(0xe34bb2103dc34f2c144cc216c132d6ffb55dac57575c22e089161bbe65083304) // keccak256(abi.encodePacked("messageId"))
         }
     }
 
@@ -130,8 +136,10 @@ contract MessageProcessor is EternalStorage {
     */
     function setMessageId(bytes32 _messageId) internal {
         assembly {
-            // keccak256(abi.encodePacked("messageId"))
-            sstore(0xe34bb2103dc34f2c144cc216c132d6ffb55dac57575c22e089161bbe65083304, _messageId)
+            // Even though this is not the same as uintStorage[keccak256(abi.encodePacked("messageId"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            sstore(0xe34bb2103dc34f2c144cc216c132d6ffb55dac57575c22e089161bbe65083304, _messageId) // keccak256(abi.encodePacked("messageId"))
         }
     }
 
@@ -141,8 +149,10 @@ contract MessageProcessor is EternalStorage {
     */
     function messageSourceChainId() external view returns (uint256 id) {
         assembly {
-            // keccak256(abi.encodePacked("messageSourceChainId"))
-            id := sload(0x7f0fcd9e49860f055dd0c1682d635d309ecb5e3011654c716d9eb59a7ddec7d2)
+            // Even though this is not the same as uintStorage[keccak256(abi.encodePacked("messageSourceChainId"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            id := sload(0x7f0fcd9e49860f055dd0c1682d635d309ecb5e3011654c716d9eb59a7ddec7d2) // keccak256(abi.encodePacked("messageSourceChainId"))
         }
     }
 
@@ -152,7 +162,10 @@ contract MessageProcessor is EternalStorage {
     */
     function setMessageSourceChainId(uint256 _sourceChainId) internal {
         assembly {
-            sstore(0x7f0fcd9e49860f055dd0c1682d635d309ecb5e3011654c716d9eb59a7ddec7d2, _sourceChainId)
+            // Even though this is not the same as uintStorage[keccak256(abi.encodePacked("messageSourceChainId"))],
+            // since solidity mapping introduces another level of addressing, such slot change is safe
+            // for temporary variables which are cleared at the end of the call execution.
+            sstore(0x7f0fcd9e49860f055dd0c1682d635d309ecb5e3011654c716d9eb59a7ddec7d2, _sourceChainId) // keccak256(abi.encodePacked("messageSourceChainId"))
         }
     }
 


### PR DESCRIPTION
It was found that the Solidity compiler does not optimize the calculation of mapping storage slots in the cases where the slot remains constant. This PR refactors the code for temporary variables that are saved and removed from the storage within a single transaction. There are two benefits of such improvement:
* Transactions become cheaper, we are saving `~50` gas at each access operation to such variable by skipping redundant . For instance, usual Omnibridge withdraw operation contains 8 such accesses.
* Bytecode size decreases: AMB contracts bytecode decreased by `~300` bytes, mediators bytecode decreased by `~100` bytes each.

Also, worth noting that such optimizations can be also applied to other storage usages as well. For example, we can precalculate the exact storage slot of `addressStorage[BRIDGE_CONTRACT]`, this will have the same effect as for temporary variables. However, such refactoring should be done with extra caution in order to maintain the exactly same storage slots as it was before. 