### PR TITLE
Helpers to collect signatures for erc20-to-native and AMB

### DIFF
--- a/contracts/helpers/AMBBridgeHelper.sol
+++ b/contracts/helpers/AMBBridgeHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.5;
+pragma solidity 0.4.24;
 
 interface IHomeBridge {
     function numMessagesSigned(bytes32 _message) external view returns (uint256);
@@ -7,12 +7,8 @@ interface IHomeBridge {
 }
 
 contract Helper {
-    function unpackSignature(bytes memory _signature) internal pure returns (bytes32, bytes32, uint8)
-    {
+    function unpackSignature(bytes memory _signature) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
         require(_signature.length == 65);
-        bytes32 r;
-        bytes32 s;
-        uint8 v;
 
         assembly {
             r := mload(add(_signature, 0x20))
@@ -24,33 +20,33 @@ contract Helper {
 }
 
 contract AMBBridgeHelper is Helper {
-    address payable owner;
-    IHomeBridge public AMBcontract;
+    address public owner;
+    IHomeBridge public ambBridge;
 
-    constructor (address _homeBridge) {
+    constructor(address _homeBridge) public {
         owner = msg.sender;
-        AMBcontract = IHomeBridge(_homeBridge);
+        ambBridge = IHomeBridge(_homeBridge);
     }
-    
-    function getSignatures(bytes calldata _message) external view returns(bytes memory) {
-        bytes32 msgHash = keccak256(abi.encodePacked(_message));
-        uint256 signed = AMBcontract.numMessagesSigned(msgHash);
 
-        require(AMBcontract.isAlreadyProcessed(signed), "message hasn't been confirmed");
-        
+    function getSignatures(bytes _message) external view returns (bytes memory) {
+        bytes32 msgHash = keccak256(abi.encodePacked(_message));
+        uint256 signed = ambBridge.numMessagesSigned(msgHash);
+
+        require(ambBridge.isAlreadyProcessed(signed), "message hasn't been confirmed");
+
         // recover number of confirmations sent by oracles
         signed = signed & 0x8fffffffffffffffffffffffffffffffffffffffffff;
-        
+
         require(signed < 0x100);
-        
+
         bytes memory signatures = new bytes(1 + signed * 65);
-        
+
         assembly {
             mstore8(add(signatures, 32), signed)
         }
 
         for (uint256 i = 0; i < signed; i++) {
-            bytes memory sig = AMBcontract.signature(msgHash, i);
+            bytes memory sig = ambBridge.signature(msgHash, i);
             (bytes32 r, bytes32 s, uint8 v) = unpackSignature(sig);
             assembly {
                 mstore8(add(add(signatures, 33), i), v)
@@ -58,7 +54,7 @@ contract AMBBridgeHelper is Helper {
                 mstore(add(add(add(signatures, 33), mul(signed, 33)), mul(i, 32)), s)
             }
         }
-        
+
         return signatures;
     }
 

--- a/contracts/helpers/AMBBridgeHelper.sol
+++ b/contracts/helpers/AMBBridgeHelper.sol
@@ -1,0 +1,69 @@
+pragma solidity 0.7.5;
+
+interface IHomeBridge {
+    function numMessagesSigned(bytes32 _message) external view returns (uint256);
+    function isAlreadyProcessed(uint256 _number) external pure returns (bool);
+    function signature(bytes32 _hash, uint256 _index) external view returns (bytes memory);
+}
+
+contract Helper {
+    function unpackSignature(bytes memory _signature) internal pure returns (bytes32, bytes32, uint8)
+    {
+        require(_signature.length == 65);
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        assembly {
+            r := mload(add(_signature, 0x20))
+            s := mload(add(_signature, 0x40))
+            v := mload(add(_signature, 0x41))
+        }
+        return (r, s, v);
+    }
+}
+
+contract AMBBridgeHelper is Helper {
+    address payable owner;
+    IHomeBridge public AMBcontract;
+
+    constructor (address _homeBridge) {
+        owner = msg.sender;
+        AMBcontract = IHomeBridge(_homeBridge);
+    }
+    
+    function getSignatures(bytes calldata _message) external view returns(bytes memory) {
+        bytes32 msgHash = keccak256(abi.encodePacked(_message));
+        uint256 signed = AMBcontract.numMessagesSigned(msgHash);
+
+        require(AMBcontract.isAlreadyProcessed(signed), "message hasn't been confirmed");
+        
+        // recover number of confirmations sent by oracles
+        signed = signed & 0x8fffffffffffffffffffffffffffffffffffffffffff;
+        
+        require(signed < 0x100);
+        
+        bytes memory signatures = new bytes(1 + signed * 65);
+        
+        assembly {
+            mstore8(add(signatures, 32), signed)
+        }
+
+        for (uint256 i = 0; i < signed; i++) {
+            bytes memory sig = AMBcontract.signature(msgHash, i);
+            (bytes32 r, bytes32 s, uint8 v) = unpackSignature(sig);
+            assembly {
+                mstore8(add(add(signatures, 33), i), v)
+                mstore(add(add(add(signatures, 33), signed), mul(i, 32)), r)
+                mstore(add(add(add(signatures, 33), mul(signed, 33)), mul(i, 32)), s)
+            }
+        }
+        
+        return signatures;
+    }
+
+    function clean() external {
+        require(msg.sender == owner, "not an owner");
+        selfdestruct(owner);
+    }
+}

--- a/contracts/helpers/Erc20ToNativeBridgeHelper.sol
+++ b/contracts/helpers/Erc20ToNativeBridgeHelper.sol
@@ -1,0 +1,81 @@
+pragma solidity 0.8.1;
+
+interface IHomeErc20ToNativeBridge {
+    function numMessagesSigned(bytes32 _message) external view returns (uint256);
+    function isAlreadyProcessed(uint256 _number) external pure returns (bool);
+    function message(bytes32 _hash) external view returns (bytes memory);
+    function signature(bytes32 _hash, uint256 _index) external view returns (bytes memory);
+}
+
+
+contract Helper {
+    function unpackSignature(bytes memory _signature) internal pure returns (bytes32 r, bytes32 s, uint8 v)
+    {
+        require(_signature.length == 65);
+
+        assembly {
+            r := mload(add(_signature, 0x20))
+            s := mload(add(_signature, 0x40))
+            v := mload(add(_signature, 0x41))
+        }
+        return (r, s, v);
+    }
+}
+
+contract Erc20ToNativeBridgeHelper is Helper {
+    address payable owner;
+    IHomeErc20ToNativeBridge public bridge;
+    address foreignBridge;
+    
+    constructor (address _homeBridge, address _foreignBridge) {
+        owner = payable(msg.sender);
+        bridge = IHomeErc20ToNativeBridge(_homeBridge);
+        foreignBridge = _foreignBridge;
+    }
+    
+    function getMessage(bytes32 _msgHash) external view returns(bytes memory result) {
+        result = bridge.message(_msgHash);
+    }
+
+    function getMessageHash(address _recipient, uint256 _value, bytes32 _origTxHash) external view returns(bytes32) {
+        bytes32 result = keccak256(abi.encodePacked(_recipient, _value, _origTxHash, foreignBridge));
+        return result;
+    }
+    
+    function getSignatures(bytes32 _msgHash) external view returns(bytes memory) {
+        uint256 signed = bridge.numMessagesSigned(_msgHash);
+
+        require(bridge.isAlreadyProcessed(signed), "message hasn't been confirmed");
+        
+        // recover number of confirmations sent by oracles
+        signed = signed & 0x8fffffffffffffffffffffffffffffffffffffffffff;
+        
+        require(signed < 0x100);
+        
+        bytes memory signatures = new bytes(1 + signed * 65);
+        
+        assembly {
+            mstore8(add(signatures, 32), signed)
+        }
+
+        for (uint256 i = 0; i < signed; i++) {
+            bytes memory sig = bridge.signature(_msgHash, i);
+            (bytes32 r, bytes32 s, uint8 v) = unpackSignature(sig);
+            assembly {
+                let ptr := add(signatures, 33)
+                mstore8(add(ptr, i), v)
+                ptr := add(ptr, signed)
+                mstore(add(ptr, mul(i, 32)), r)
+                ptr := add(ptr, mul(signed, 32))
+                mstore(add(ptr, mul(i, 32)), s)
+            }
+        }
+        
+        return signatures;
+    }
+
+    function clean() external {
+        require(msg.sender == owner, "not an owner");
+        selfdestruct(owner);
+    }
+}

--- a/contracts/helpers/Erc20ToNativeBridgeHelper.sol
+++ b/contracts/helpers/Erc20ToNativeBridgeHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.1;
+pragma solidity 0.4.24;
 
 interface IHomeErc20ToNativeBridge {
     function numMessagesSigned(bytes32 _message) external view returns (uint256);
@@ -7,10 +7,8 @@ interface IHomeErc20ToNativeBridge {
     function signature(bytes32 _hash, uint256 _index) external view returns (bytes memory);
 }
 
-
 contract Helper {
-    function unpackSignature(bytes memory _signature) internal pure returns (bytes32 r, bytes32 s, uint8 v)
-    {
+    function unpackSignature(bytes memory _signature) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
         require(_signature.length == 65);
 
         assembly {
@@ -23,37 +21,37 @@ contract Helper {
 }
 
 contract Erc20ToNativeBridgeHelper is Helper {
-    address payable owner;
+    address public owner;
     IHomeErc20ToNativeBridge public bridge;
-    address foreignBridge;
-    
-    constructor (address _homeBridge, address _foreignBridge) {
-        owner = payable(msg.sender);
+    address public foreignBridge;
+
+    constructor(address _homeBridge, address _foreignBridge) public {
+        owner = msg.sender;
         bridge = IHomeErc20ToNativeBridge(_homeBridge);
         foreignBridge = _foreignBridge;
     }
-    
-    function getMessage(bytes32 _msgHash) external view returns(bytes memory result) {
+
+    function getMessage(bytes32 _msgHash) external view returns (bytes memory result) {
         result = bridge.message(_msgHash);
     }
 
-    function getMessageHash(address _recipient, uint256 _value, bytes32 _origTxHash) external view returns(bytes32) {
+    function getMessageHash(address _recipient, uint256 _value, bytes32 _origTxHash) external view returns (bytes32) {
         bytes32 result = keccak256(abi.encodePacked(_recipient, _value, _origTxHash, foreignBridge));
         return result;
     }
-    
-    function getSignatures(bytes32 _msgHash) external view returns(bytes memory) {
+
+    function getSignatures(bytes32 _msgHash) external view returns (bytes memory) {
         uint256 signed = bridge.numMessagesSigned(_msgHash);
 
         require(bridge.isAlreadyProcessed(signed), "message hasn't been confirmed");
-        
+
         // recover number of confirmations sent by oracles
         signed = signed & 0x8fffffffffffffffffffffffffffffffffffffffffff;
-        
+
         require(signed < 0x100);
-        
+
         bytes memory signatures = new bytes(1 + signed * 65);
-        
+
         assembly {
             mstore8(add(signatures, 32), signed)
         }
@@ -70,7 +68,7 @@ contract Erc20ToNativeBridgeHelper is Helper {
                 mstore(add(ptr, mul(i, 32)), s)
             }
         }
-        
+
         return signatures;
     }
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -24,7 +24,7 @@ const provider = new Web3ProviderEngine()
 if (process.env.SOLIDITY_COVERAGE === 'true') {
   global.coverageSubprovider = new CoverageSubprovider(artifactAdapter, defaultFromAddress, {
     isVerbose,
-    ignoreFilesGlobs: ['**/Migrations.sol', '**/node_modules/**', '**/mocks/**', '**/interfaces/**']
+    ignoreFilesGlobs: ['**/Migrations.sol', '**/node_modules/**', '**/mocks/**', '**/interfaces/**', '**/helpers/**']
   })
   provider.addProvider(global.coverageSubprovider)
   const ganacheSubprovider = new GanacheSubprovider({


### PR DESCRIPTION
@k1rill-fedoseev has prepared two helpers which were deployed to xDai chain to help users manually collect signatures provided by the bridge oracles. The collected signatures are being used on another side of the bridge to execute the transfer.