### PR TITLE
Bump contracts and package version before 5.7.0-rc0

### DIFF
--- a/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
@@ -17,6 +17,6 @@ contract VersionableAMB is VersionableBridge {
      * @return (major, minor, patch) version triple
      */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (5, 6, 0);
+        return (5, 7, 0);
     }
 }

--- a/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
+++ b/contracts/upgradeable_contracts/multi_amb_erc20_to_erc677/BasicMultiAMBErc20ToErc677.sol
@@ -58,7 +58,7 @@ contract BasicMultiAMBErc20ToErc677 is
     * @return patch value of the version
     */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (1, 4, 0);
+        return (1, 5, 0);
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.6.0",
+  "version": "5.7.0-rc0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.6.0",
+  "version": "5.7.0-rc0",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since [the code delta between `5.6.0` and `5.7.0-rc0`](https://github.com/poanetwork/tokenbridge-contracts/compare/5.6.0...1ae26c0ddefdc65cfdb41122919a43bdeb0605a2) contains the changes in AMB and OB contracts, the version tracking methods in the corresponding contracts were updated.

The package version was updated to be linked to the `5.7.0-rc0` release.