### PR TITLE
Bump contracts and package version before 5.7.0-rc1

### DIFF
--- a/contracts/upgradeable_contracts/VersionableBridge.sol
+++ b/contracts/upgradeable_contracts/VersionableBridge.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 contract VersionableBridge {
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (5, 2, 0);
+        return (6, 0, 0);
     }
 
     /* solcov ignore next */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.7.0-rc0",
+  "version": "5.7.0-rc1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.7.0-rc0",
+  "version": "5.7.0-rc1",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Major of the bridge contracts was changed to `6.0.0` because the erc20-to-native contracts were reworked to support another scheme to earn interest

The package version was updated to be linked to the `5.7.0-rc1` release.