### PR TITLE
Bump package version before 6.0.0-rc0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.7.0-rc1",
+  "version": "6.0.0-rc0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "5.7.0-rc1",
+  "version": "6.0.0-rc0",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The package major version is increased because the contracts for both bridge mode were significantly changed since the latest release (`5.6.0`).