### PR TITLE
Stricter preconditions for payInterest

### DIFF
--- a/contracts/upgradeable_contracts/InterestReceiverStakeBuyback.sol
+++ b/contracts/upgradeable_contracts/InterestReceiverStakeBuyback.sol
@@ -26,14 +26,6 @@ contract InterestReceiverStakeBuyback is InterestReceiverBase {
         // (min received %) * (amount / 1 DAI) * (STAKE per 1 DAI)
         uint256 minAmount = (minReceivedFraction * amount * uniswapRouterV2.getAmountsOut(1 ether, path)[2]) / 10**36;
 
-        bytes memory data = abi.encodeWithSelector(
-            uniswapRouterV2.swapExactTokensForTokens.selector,
-            amount,
-            minAmount,
-            path,
-            burnAddress,
-            now
-        );
-        address(uniswapRouterV2).call(data);
+        uniswapRouterV2.swapExactTokensForTokens(amount, minAmount, path, burnAddress, now);
     }
 }

--- a/contracts/upgradeable_contracts/InterestReceiverSwapToETH.sol
+++ b/contracts/upgradeable_contracts/InterestReceiverSwapToETH.sol
@@ -22,15 +22,7 @@ contract InterestReceiverSwapToETH is InterestReceiverBase {
         // (min received %) * (amount / 1 DAI) * (ETH per 1 DAI)
         uint256 minAmount = (minReceivedFraction * amount * uniswapRouterV2.getAmountsOut(1 ether, path)[1]) / 10**36;
 
-        bytes memory data = abi.encodeWithSelector(
-            uniswapRouterV2.swapExactTokensForETH.selector,
-            amount,
-            minAmount,
-            path,
-            address(this),
-            now
-        );
-        address(uniswapRouterV2).call(data);
+        uniswapRouterV2.swapExactTokensForETH(amount, minAmount, path, address(this), now);
     }
 
     /**

--- a/contracts/upgradeable_contracts/erc20_to_native/CompoundConnector.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/CompoundConnector.sol
@@ -86,7 +86,7 @@ contract CompoundConnector is InterestConnector {
     /**
      * @dev Claims Comp token and transfers it to the associated interest receiver.
      */
-    function claimCompAndPay() external {
+    function claimCompAndPay() external onlyEOA {
         address[] memory holders = new address[](1);
         holders[0] = address(this);
         address[] memory markets = new address[](1);

--- a/contracts/upgradeable_contracts/erc20_to_native/InterestConnector.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/InterestConnector.sol
@@ -22,6 +22,17 @@ contract InterestConnector is Ownable, ERC20Bridge {
     }
 
     /**
+     * @dev Ensures that caller is an EOA.
+     * Functions with such modifier cannot be called from other contract (as well as from GSN-like approaches)
+     */
+    modifier onlyEOA {
+        // solhint-disable-next-line avoid-tx-origin
+        require(msg.sender == tx.origin);
+        /* solcov ignore next */
+        _;
+    }
+
+    /**
      * @dev Tells if interest earning was enabled for particular token.
      * @return true, if interest bearing  is enabled.
      */
@@ -123,7 +134,7 @@ contract InterestConnector is Ownable, ERC20Bridge {
      * Requires interest for the given token to be enabled.
      * @param _token address of the token contract.
      */
-    function payInterest(address _token) external interestEnabled(_token) {
+    function payInterest(address _token) external onlyEOA interestEnabled(_token) {
         uint256 interest = interestAmount(_token);
         require(interest >= minInterestPaid(_token));
 


### PR DESCRIPTION
The `InterestReceiverStakeBuyback` and `InterestReceiverSwapToETH` contracts both utilize Uniswap in order to swap tokens. There is some slippage protection, but no protection against price manipulation is built in.

Because the `payInterest` function in the `InterestConnector` is external and permissionless, anyone can call it at any time. Therefore, once enough interest accrues, one could take out a flash loan to manipulate the relevant Uniswap pools and call `payInterest` to make a profit.

Additionally, even if `payInterest` weren't permissionless, it is possible for the Uniswap call in `onInterestReceived` to fail, leaving the tokens sitting in the `InterestReceiver` contract. Here, the `onInterestReceived` function is external and permissionless, meaning it's once again prone to being attacked via price manipulation.

Furthermore, assuming the interest payment was not callable by untrusted parties at all, it would still be possible to manipulate the price by sandwiching that transaction between two others, either by chance or by collusion with miners.

The fix is to disable ability of storing tokens on the interest receiver contract and introduces extra EOA-only check to payInterest method.

This reduces the risk of possible price manipulations, since it is no longer possible to use flash-loans to perform an attack. 

Front-running of the transaction is considered less dangerous, as it requires a much higher attack cost (at least 2 Uniswap transactions gas fees + 2 slippage and swap fees).