### PR TITLE
Fix offset in comments

### DIFF
--- a/contracts/libraries/Message.sol
+++ b/contracts/libraries/Message.sol
@@ -15,7 +15,7 @@ library Message {
     // offset 32: 20 bytes :: address - recipient address
     // offset 52: 32 bytes :: uint256 - value
     // offset 84: 32 bytes :: bytes32 - transaction hash
-    // offset 104: 20 bytes :: address - contract address to prevent double spending
+    // offset 116: 20 bytes :: address - contract address to prevent double spending
 
     // mload always reads 32 bytes.
     // so we can and have to start reading recipient at offset 20 instead of 32.


### PR DESCRIPTION
The function parseMessage is preceded by a comment about the offsets of the different parts within the message. It contains:
https://github.com/poanetwork/tokenbridge-contracts/blob/b3511bf0987bbfef661e28dd1a6fbe1735f90ac0/contracts/libraries/Message.sol#L18
However the correct offset is 116. The code implements it correctly.