### PR TITLE
Update GSN interface

### DIFF
--- a/contracts/gsn/BasePaymaster.sol
+++ b/contracts/gsn/BasePaymaster.sol
@@ -4,7 +4,6 @@ pragma experimental ABIEncoderV2;
 
 import "../upgradeable_contracts/Ownable.sol";
 
-import "./interfaces/GsnTypes.sol";
 import "./interfaces/IPaymaster.sol";
 import "./interfaces/IRelayHub.sol";
 import "./utils/GsnEip712Library.sol";
@@ -18,7 +17,7 @@ import "./forwarder/IForwarder.sol";
  */
 contract BasePaymaster is IPaymaster, Ownable {
     IRelayHub internal relayHub;
-    IForwarder public trustedForwarder;
+    address private _trustedForwarder;
 
     function getHubAddr() public view returns (address) {
         return address(relayHub);
@@ -27,20 +26,26 @@ contract BasePaymaster is IPaymaster, Ownable {
     //overhead of forwarder verify+signature, plus hub overhead.
     uint256 public constant FORWARDER_HUB_OVERHEAD = 50000;
 
-    //These parameters are documented in IPaymaster.GasLimits
+    //These parameters are documented in IPaymaster.GasAndDataLimits
     uint256 public constant PRE_RELAYED_CALL_GAS_LIMIT = 100000;
     uint256 public constant POST_RELAYED_CALL_GAS_LIMIT = 110000;
     uint256 public constant PAYMASTER_ACCEPTANCE_BUDGET = PRE_RELAYED_CALL_GAS_LIMIT + FORWARDER_HUB_OVERHEAD;
+    uint256 public constant CALLDATA_SIZE_LIMIT = 10500;
 
-    function getGasLimits() external view returns (IPaymaster.GasLimits) {
+    function getGasAndDataLimits() external view returns (IPaymaster.GasAndDataLimits limits) {
         return
-            IPaymaster.GasLimits(PAYMASTER_ACCEPTANCE_BUDGET, PRE_RELAYED_CALL_GAS_LIMIT, POST_RELAYED_CALL_GAS_LIMIT);
+            IPaymaster.GasAndDataLimits(
+                PAYMASTER_ACCEPTANCE_BUDGET,
+                PRE_RELAYED_CALL_GAS_LIMIT,
+                POST_RELAYED_CALL_GAS_LIMIT,
+                CALLDATA_SIZE_LIMIT
+            );
     }
 
     // this method must be called from preRelayedCall to validate that the forwarder
     // is approved by the paymaster as well as by the recipient contract.
     function _verifyForwarder(GsnTypes.RelayRequest relayRequest) public view {
-        require(address(trustedForwarder) == relayRequest.relayData.forwarder, "Forwarder is not trusted");
+        require(address(_trustedForwarder) == relayRequest.relayData.forwarder, "Forwarder is not trusted");
         GsnEip712Library.verifyForwarderTrusted(relayRequest);
     }
 
@@ -48,7 +53,7 @@ contract BasePaymaster is IPaymaster, Ownable {
      * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
      */
     modifier relayHubOnly() {
-        require(msg.sender == getHubAddr(), "Function can only be called by RelayHub");
+        require(msg.sender == getHubAddr(), "can only be called by RelayHub");
         _;
     }
 
@@ -56,16 +61,28 @@ contract BasePaymaster is IPaymaster, Ownable {
         relayHub = hub;
     }
 
-    function setTrustedForwarder(IForwarder forwarder) public onlyOwner {
-        trustedForwarder = forwarder;
+    function setTrustedForwarder(address forwarder) public onlyOwner {
+        _trustedForwarder = forwarder;
     }
 
-    // check current deposit on relay hub.
-    function getRelayHubDeposit() public view returns (uint256) {
+    function trustedForwarder() external view returns (address) {
+        return _trustedForwarder;
+    }
+
+    /// check current deposit on relay hub.
+    function getRelayHubDeposit() external view returns (uint256) {
         return relayHub.balanceOf(address(this));
     }
 
-    // withdraw deposit from relayHub
+    // any eth moved into the paymaster is transferred as a deposit.
+    // This way, we don't need to understand the RelayHub API in order to replenish
+    // the paymaster.
+    function() external payable {
+        require(address(relayHub) != address(0), "relay hub address not set");
+        relayHub.depositFor.value(msg.value)(address(this));
+    }
+
+    /// withdraw deposit from relayHub
     function withdrawRelayHubDepositTo(uint256 amount, address target) public onlyOwner {
         relayHub.withdraw(amount, target);
     }

--- a/contracts/gsn/forwarder/IForwarder.sol
+++ b/contracts/gsn/forwarder/IForwarder.sol
@@ -10,7 +10,12 @@ contract IForwarder {
         uint256 gas;
         uint256 nonce;
         bytes data;
+        uint256 validUntil;
     }
+
+    event DomainRegistered(bytes32 indexed domainSeparator, bytes domainValue);
+
+    event RequestTypeRegistered(bytes32 indexed typeHash, string typeStr);
 
     function getNonce(address from) external view returns (uint256);
 
@@ -18,6 +23,7 @@ contract IForwarder {
      * verify the transaction would execute.
      * validate the signature and the nonce of the request.
      * revert if either signature or nonce are incorrect.
+     * also revert if domainSeparator or requestTypeHash are not registered.
      */
     function verify(
         ForwardRequest forwardRequest,
@@ -51,8 +57,8 @@ contract IForwarder {
     /**
      * Register a new Request typehash.
      * @param typeName - the name of the request type.
-     * @param typeSuffix - anything after the generic params can be empty string (if no extra fields are needed)
-     *        if it does contain a value, then a comma is added first.
+     * @param typeSuffix - any extra data after the generic params.
+     *  (must add at least one param. The generic ForwardRequest type is always registered by the constructor)
      */
     function registerRequestType(string typeName, string typeSuffix) external;
 

--- a/contracts/gsn/interfaces/GsnTypes.sol
+++ b/contracts/gsn/interfaces/GsnTypes.sol
@@ -4,15 +4,16 @@ pragma solidity 0.4.24;
 import "../forwarder/IForwarder.sol";
 
 contract GsnTypes {
+    /// @notice gasPrice, pctRelayFee and baseRelayFee must be validated inside of the paymaster's preRelayedCall in order not to overpay
     struct RelayData {
         uint256 gasPrice;
         uint256 pctRelayFee;
         uint256 baseRelayFee;
         address relayWorker;
         address paymaster;
+        address forwarder;
         bytes paymasterData;
         uint256 clientId;
-        address forwarder;
     }
 
     //note: must start with the ForwardRequest to be an extension of the generic forwarder

--- a/contracts/gsn/interfaces/IPaymaster.sol
+++ b/contracts/gsn/interfaces/IPaymaster.sol
@@ -29,16 +29,19 @@ contract IPaymaster {
      *      note that an OOG will revert the transaction, but the paymaster already committed to pay,
      *      so the relay will get compensated, at the expense of the paymaster
      */
-    struct GasLimits {
+    struct GasAndDataLimits {
         uint256 acceptanceBudget;
         uint256 preRelayedCallGasLimit;
         uint256 postRelayedCallGasLimit;
+        uint256 calldataSizeLimit;
     }
 
     /**
-     * Return the GasLimits constants used by the Paymaster.
+     * Return the Gas Limits and msg.data max size constants used by the Paymaster.
      */
-    function getGasLimits() external view returns (GasLimits memory limits);
+    function getGasAndDataLimits() external view returns (GasAndDataLimits memory limits);
+
+    function trustedForwarder() external view returns (address);
 
     /**
      * return the relayHub of this contract.
@@ -49,7 +52,7 @@ contract IPaymaster {
      * Can be used to determine if the contract can pay for incoming calls before making any.
      * @return the paymaster's deposit in the RelayHub.
      */
-    function getRelayHubDeposit() public view returns (uint256);
+    function getRelayHubDeposit() external view returns (uint256);
 
     /**
      * Called by Relay (and RelayHub), to validate if the paymaster agrees to pay for this call.
@@ -74,7 +77,7 @@ contract IPaymaster {
      *              Note that in most cases the paymaster shouldn't try use it at all. It is always checked
      *              by the forwarder immediately after preRelayedCall returns.
      *  @param approvalData - extra dapp-specific data (e.g. signature from trusted party)
-     *  @param maxPossibleGas - based on values returned from {@link getGasLimits},
+     *  @param maxPossibleGas - based on values returned from {@link getGasAndDataLimits},
      *         the RelayHub will calculate the maximum possible amount of gas the user may be charged for.
      *         In order to convert this value to wei, the Paymaster has to call "relayHub.calculateCharge()"
      *  return:

--- a/contracts/gsn/token_paymaster/TokenPaymaster.sol
+++ b/contracts/gsn/token_paymaster/TokenPaymaster.sol
@@ -15,7 +15,9 @@ contract TokenPaymaster is BasePaymaster, Claimable {
 
     address[] private tokenWethPair = new address[](2);
     uint256 public postGasUsage = 300000;
-    uint256 public calldataSizeLimit = 1348;
+    // Default value from BasePaymaster, may be changed later
+    // if we need to increase number of signatures for bridge contract
+    uint256 public calldataSizeLimit = 10500;
 
     constructor(address _relayHub, address _forwarder, address _token, address _router, address _bridge) public {
         _setOwner(msg.sender);

--- a/contracts/upgradeable_contracts/GSNForeignERC20Bridge.sol
+++ b/contracts/upgradeable_contracts/GSNForeignERC20Bridge.sol
@@ -36,7 +36,8 @@ contract GSNForeignERC20Bridge is BasicForeignBridge, ERC20Bridge, BaseRelayReci
     * as a commission
     */
     function executeSignaturesGSN(bytes message, bytes signatures, uint256 maxTokensFee) external {
-        require(msg.sender == addressStorage[TRUSTED_FORWARDER], "invalid forwarder");
+        // Allow only forwarder calls
+        require(isTrustedForwarder(msg.sender), "invalid forwarder");
         Message.hasEnoughValidSignatures(message, signatures, validatorContract(), false);
 
         address recipient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,87 +3063,39 @@
         "fastq": "^1.6.0"
       }
     },
-    "@openeth/truffle-typings": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@openeth/truffle-typings/-/truffle-typings-0.0.6.tgz",
-      "integrity": "sha512-GWFDMVmisKDLTqIg0dZO3Wkri/EW8KNsETqoQB6iyAf/ULPxcAdMy5fCt02GlarL32s87M+B9kNbJ6znmDIWsw==",
+    "@opengsn/cli": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@opengsn/cli/-/cli-2.2.2.tgz",
+      "integrity": "sha512-kfGvGUCz06cbUXsqIqbOvhjtyOVKcMrFZAz4N24stE4X5CNYATG1XA0qmUsAgUu67Gj/gBuEMunZ84KeXzu9Aw==",
       "requires": {
-        "@types/chai": "^4.1.4",
-        "@types/mocha": "^5.2.5",
-        "@types/web3": "^1.2.2",
-        "web3": "1.2.6"
-      }
-    },
-    "@opengsn/gsn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@opengsn/gsn/-/gsn-2.1.0.tgz",
-      "integrity": "sha512-QEHLc8ckiQA9Aa1iJH0+rN8aZSncaUzgonH5wX8YILmmYJCG+4IsdhhamkWotK2gINVY3z6jaEQKc/SYwizs1g==",
-      "requires": {
-        "@openeth/truffle-typings": "0.0.6",
-        "@openzeppelin/contracts": "^3.2.0",
+        "@opengsn/common": "^2.2.2",
+        "@opengsn/provider": "^2.2.2",
+        "@opengsn/relay": "^2.2.2",
         "@truffle/hdwallet-provider": "1.0.34",
-        "@types/chai": "^4.2.12",
-        "@types/chai-as-promised": "^7.1.3",
-        "@types/cors": "^2.8.7",
-        "@types/eth-sig-util": "2.1.0",
-        "@types/express": "^4.17.8",
-        "@types/lodash": "^4.14.161",
-        "@types/minimist": "^1.2.0",
-        "@types/nedb": "^1.8.11",
+        "@types/asciichart": "^1.5.4",
+        "@types/clear": "^0.1.1",
+        "@types/cli-table": "^0.3.0",
         "@types/node": "^13.0.0",
-        "@types/semver": "^7.3.4",
-        "@types/sinon": "^9.0.0",
-        "@types/sinon-chai": "^3.2.5",
-        "@types/web3": "1.2.2",
         "@types/web3-provider-engine": "^14.0.0",
-        "abi-decoder": "^2.3.0",
-        "async-mutex": "^0.2.4",
-        "axios": "^0.20.0",
-        "bn.js": "5.1.2",
-        "body-parser": "^1.19.0",
-        "chai": "^4.2.0",
+        "asciichart": "^1.5.25",
         "chalk": "^4.1.0",
+        "clear": "^0.1.0",
+        "cli-table": "^0.3.4",
+        "colors": "^1.4.0",
         "commander": "^6.1.0",
         "console-read-write": "^0.1.1",
         "date-format": "^3.0.0",
-        "eth-sig-util": "2.5.2",
-        "ethereumjs-common": "^1.5.2",
         "ethereumjs-tx": "^2.1.2",
-        "ethereumjs-util": "^6.2.1",
-        "ethereumjs-wallet": "0.6.3",
-        "ethval": "^2.1.1",
-        "express": "^4.17.1",
-        "jsonrpc-lite": "^2.2.0",
-        "lodash": "^4.17.20",
-        "loglevel": "^1.7.0",
-        "minimist": "^1.2.5",
-        "nedb-async": "^0.1.3",
-        "ow": "^0.17.0",
-        "patch-package": "^6.2.2",
-        "semver": "^7.3.2",
-        "web3": "1.2.6",
-        "web3-core": "1.2.6",
-        "web3-core-helpers": "1.2.6",
-        "web3-eth": "1.2.6",
-        "web3-eth-abi": "1.2.6",
-        "web3-eth-contract": "1.2.6",
-        "web3-utils": "1.2.6",
+        "moment": "^2.29.1",
+        "terminal-link": "^2.1.1",
+        "web3-provider-engine": "14.1.0",
         "winston": "^3.3.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.51",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.51.tgz",
-          "integrity": "sha512-66/xg5I5Te4oGi5Jws11PtNmKkZbOPZWyBZZ/l5AOrWj1Dyw+6Ge/JhYTq/2/Yvdqyhrue8RL+DGI298OJ0xcg=="
-        },
-        "abi-decoder": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.4.0.tgz",
-          "integrity": "sha512-TOLU2q1HgYOjs1GKGtVzaqrYkar6I2fT9a80rzx6/9EJ/5crb4nCGuro0grZayixem93T7omrajYmLiMkYDLDA==",
-          "requires": {
-            "web3-eth-abi": "^1.2.1",
-            "web3-utils": "^1.2.1"
-          }
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -3153,18 +3105,36 @@
             "color-convert": "^2.0.1"
           }
         },
-        "bn.js": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "cli-table": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
+          "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+          "requires": {
+            "colors": "1.0.3"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+            }
           }
         },
         "color-convert": {
@@ -3180,20 +3150,28 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
         },
         "elliptic": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
           "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
             "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
           },
           "dependencies": {
             "bn.js": {
@@ -3202,111 +3180,6 @@
               "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
             }
           }
-        },
-        "eth-sig-util": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.2.tgz",
-          "integrity": "sha512-xvDojS/4reXsw8Pz/+p/qcM5rVB61FOdPbEtMZ8FQ0YHnPEzPy5F8zAAaZ+zj5ud0SwRLWPfor2Cacjm7EzMIw==",
-          "requires": {
-            "buffer": "^5.2.1",
-            "elliptic": "^6.4.0",
-            "ethereumjs-abi": "0.6.5",
-            "ethereumjs-util": "^5.1.1",
-            "tweetnacl": "^1.0.0",
-            "tweetnacl-util": "^0.15.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-            },
-            "elliptic": {
-              "version": "6.5.4",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-              "requires": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-              }
-            },
-            "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-            }
-          }
-        },
-        "ethereumjs-abi": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
-          "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
-          "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^4.3.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-            },
-            "elliptic": {
-              "version": "6.5.4",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-              "requires": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-              }
-            },
-            "ethereumjs-util": {
-              "version": "4.5.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-              "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
-              "requires": {
-                "bn.js": "^4.8.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "rlp": "^2.0.0"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-            }
-          }
-        },
-        "ethereumjs-common": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-          "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
         },
         "ethereumjs-tx": {
           "version": "2.1.2",
@@ -3329,8 +3202,226 @@
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "14.1.0",
+          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.1.0.tgz",
+          "integrity": "sha512-vGZtqhSUzGTiMGhJXNnB/aRDlrPZLhLnBZ2NPArkZtr8XSrwg9m08tw4+PuWg5za0TJuoE/vuPQc501HddZZWw==",
+          "requires": {
+            "async": "^2.5.0",
+            "backoff": "^2.5.0",
+            "clone": "^2.0.0",
+            "cross-fetch": "^2.1.0",
+            "eth-block-tracker": "^3.0.0",
+            "eth-json-rpc-infura": "^3.1.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.1.5",
+            "ethereumjs-vm": "^2.3.4",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "readable-stream": "^2.2.9",
+            "request": "^2.85.0",
+            "semaphore": "^1.0.3",
+            "ws": "^5.1.1",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
           },
           "dependencies": {
+            "ethereumjs-tx": {
+              "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+              "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+              "requires": {
+                "ethereum-common": "^0.0.18",
+                "ethereumjs-util": "^5.0.0"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@opengsn/common": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@opengsn/common/-/common-2.2.2.tgz",
+      "integrity": "sha512-eofc4jkwGWNjS70LZyWs3c1nM4TKCyBIy/crTXv4zRUoGUEN4QlVYbd13p+RWYtF8nNZ6hHJFs3Iel3nRasYFA==",
+      "requires": {
+        "@opengsn/contracts": "^2.2.2",
+        "@types/bn.js": "^5.1.0",
+        "@types/eth-sig-util": "^2.1.0",
+        "@types/semver": "^7.3.4",
+        "@types/web3": "1.2.2",
+        "axios": "^0.21.1",
+        "bn.js": "^5.2.0",
+        "chalk": "^4.1.0",
+        "eth-sig-util": "2.5.2",
+        "ethereumjs-tx": "^2.1.2",
+        "ethereumjs-util": "^7.0.10",
+        "ethval": "^2.1.1",
+        "ow": "^0.17.0",
+        "rlp": "^2.2.6",
+        "semver": "^7.3.2",
+        "web3-core": "1.2.6",
+        "web3-core-helpers": "1.2.6",
+        "web3-eth": "1.2.6",
+        "web3-eth-abi": "1.2.6",
+        "web3-eth-contract": "1.2.6",
+        "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "eth-sig-util": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.2.tgz",
+          "integrity": "sha512-xvDojS/4reXsw8Pz/+p/qcM5rVB61FOdPbEtMZ8FQ0YHnPEzPy5F8zAAaZ+zj5ud0SwRLWPfor2Cacjm7EzMIw==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "elliptic": "^6.4.0",
+            "ethereumjs-abi": "0.6.5",
+            "ethereumjs-util": "^5.1.1",
+            "tweetnacl": "^1.0.0",
+            "tweetnacl-util": "^0.15.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            },
+            "ethereumjs-util": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              },
+              "dependencies": {
+                "elliptic": {
+                  "version": "6.5.4",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+                  "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+                  "requires": {
+                    "bn.js": "^4.11.9",
+                    "brorand": "^1.1.0",
+                    "hash.js": "^1.0.0",
+                    "hmac-drbg": "^1.0.1",
+                    "inherits": "^2.0.4",
+                    "minimalistic-assert": "^1.0.1",
+                    "minimalistic-crypto-utils": "^1.0.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
             "bn.js": {
               "version": "4.12.0",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -3350,11 +3441,33 @@
                 "minimalistic-crypto-utils": "^1.0.1"
               }
             },
-            "inherits": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "ethereumjs-util": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.3"
+              }
             }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
           }
         },
         "ethers": {
@@ -3374,15 +3487,30 @@
             "xmlhttprequest": "1.8.0"
           },
           "dependencies": {
-            "@types/node": {
-              "version": "10.17.59",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-              "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
-            },
             "bn.js": {
               "version": "4.12.0",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
               "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "hash.js": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+              "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
+              }
             }
           }
         },
@@ -3391,29 +3519,10 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "loglevel": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
-          "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -3423,10 +3532,20 @@
             "yallist": "^4.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        "rlp": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
         },
         "scrypt-js": {
           "version": "2.0.3",
@@ -3495,6 +3614,253 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@opengsn/contracts": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@opengsn/contracts/-/contracts-2.2.2.tgz",
+      "integrity": "sha512-GnV6Z5ZoWkVhd+rWbC30SpoX45fPndp1bcLV3t5QE2lRBFOjNk0guD/2i2k/RzbJiiFj9RvScufecC8N+0Rhvg==",
+      "requires": {
+        "@openzeppelin/contracts": "^3.4.0-solc-0.7"
+      }
+    },
+    "@opengsn/provider": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@opengsn/provider/-/provider-2.2.2.tgz",
+      "integrity": "sha512-oqevZOC1+uNnfh17XSB7u3Xn0TLSgLAE1IA3LDrzLW6VA5GyhshKgMArqzL2qTZN5m7W9mwot2pihIcqn/Ad+w==",
+      "requires": {
+        "@opengsn/common": "^2.2.2",
+        "@types/body-parser": "^1.19.0",
+        "@types/eth-sig-util": "^2.1.0",
+        "@types/express-serve-static-core": "^4.17.18",
+        "abi-decoder": "^2.4.0",
+        "body-parser": "^1.19.0",
+        "eth-sig-util": "2.5.2",
+        "ethereumjs-tx": "^2.1.2",
+        "ethereumjs-util": "^6.2.1",
+        "ethereumjs-wallet": "^0.6.5",
+        "loglevel": "^1.7.1",
+        "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "abi-decoder": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.4.0.tgz",
+          "integrity": "sha512-TOLU2q1HgYOjs1GKGtVzaqrYkar6I2fT9a80rzx6/9EJ/5crb4nCGuro0grZayixem93T7omrajYmLiMkYDLDA==",
+          "requires": {
+            "web3-eth-abi": "^1.2.1",
+            "web3-utils": "^1.2.1"
+          }
+        },
+        "aes-js": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+          "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+        },
+        "eth-sig-util": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.2.tgz",
+          "integrity": "sha512-xvDojS/4reXsw8Pz/+p/qcM5rVB61FOdPbEtMZ8FQ0YHnPEzPy5F8zAAaZ+zj5ud0SwRLWPfor2Cacjm7EzMIw==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "elliptic": "^6.4.0",
+            "ethereumjs-abi": "0.6.5",
+            "ethereumjs-util": "^5.1.1",
+            "tweetnacl": "^1.0.0",
+            "tweetnacl-util": "^0.15.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              },
+              "dependencies": {
+                "elliptic": {
+                  "version": "6.5.4",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+                  "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+                  "requires": {
+                    "bn.js": "^4.11.9",
+                    "brorand": "^1.1.0",
+                    "hash.js": "^1.0.0",
+                    "hmac-drbg": "^1.0.1",
+                    "inherits": "^2.0.4",
+                    "minimalistic-assert": "^1.0.1",
+                    "minimalistic-crypto-utils": "^1.0.1"
+                  },
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "4.12.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.4",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+              "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.12.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                  "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+                }
+              }
+            }
+          }
+        },
+        "ethereumjs-wallet": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
+          "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
+          "requires": {
+            "aes-js": "^3.1.1",
+            "bs58check": "^2.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethereumjs-util": "^6.0.0",
+            "randombytes": "^2.0.6",
+            "safe-buffer": "^5.1.2",
+            "scryptsy": "^1.2.1",
+            "utf8": "^3.0.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "loglevel": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+          "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+        },
+        "scryptsy": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+          "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+          "requires": {
+            "pbkdf2": "^3.0.3"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "@opengsn/relay": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@opengsn/relay/-/relay-2.2.2.tgz",
+      "integrity": "sha512-RuNeEUrrniZrxnrb3fohxHjKr1kRsQT3CuN30pq8jH26XRWgEdjtRxg0YxeiQ4eudRJ4EkWdEXoCfEP5G9rmog==",
+      "requires": {
+        "@opengsn/common": "^2.2.2",
+        "@types/cors": "^2.8.7",
+        "@types/express": "^4.17.8",
+        "@types/minimist": "^1.2.0",
+        "@types/nedb": "^1.8.11",
+        "async-mutex": "^0.2.4",
+        "ethereumjs-tx": "^2.1.2",
+        "ethereumjs-util": "^6.2.1",
+        "nedb-async": "^0.1.3"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         }
       }
     },
@@ -5314,6 +5680,22 @@
             "web3-net": "1.2.1",
             "web3-shh": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-bzz": {
@@ -5335,6 +5717,22 @@
             "web3-core-method": "1.2.1",
             "web3-core-requestmanager": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-helpers": {
@@ -5345,6 +5743,22 @@
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-method": {
@@ -5357,6 +5771,22 @@
             "web3-core-promievent": "1.2.1",
             "web3-core-subscriptions": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-promievent": {
@@ -5408,6 +5838,22 @@
             "web3-eth-personal": "1.2.1",
             "web3-net": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-accounts": {
@@ -5426,6 +5872,22 @@
             "web3-core-helpers": "1.2.1",
             "web3-core-method": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-contract": {
@@ -5441,6 +5903,22 @@
             "web3-core-subscriptions": "1.2.1",
             "web3-eth-abi": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-ens": {
@@ -5456,6 +5934,22 @@
             "web3-eth-abi": "1.2.1",
             "web3-eth-contract": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-iban": {
@@ -5465,6 +5959,22 @@
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-personal": {
@@ -5477,6 +5987,22 @@
             "web3-core-method": "1.2.1",
             "web3-net": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-net": {
@@ -5487,6 +6013,22 @@
             "web3-core": "1.2.1",
             "web3-core-method": "1.2.1",
             "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-provider-engine": {
@@ -7058,6 +7600,11 @@
         "@types/node": "*"
       }
     },
+    "@types/asciichart": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/asciichart/-/asciichart-1.5.6.tgz",
+      "integrity": "sha512-GXq4BojlHJHRlizP9zXQfhgMbAy+kmyMyfV9P6vyYxUE302Km8GU0ebToQ1YVlGlFypVOYWNxqEWWLQW0HzFgA=="
+    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -7075,18 +7622,15 @@
         "@types/node": "*"
       }
     },
-    "@types/chai": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.17.tgz",
-      "integrity": "sha512-LaiwWNnYuL8xJlQcE91QB2JoswWZckq9A4b+nMPq8dt8AP96727Nb3X4e74u+E3tm4NLTILNI9MYFsyVc30wSA=="
+    "@types/clear": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/clear/-/clear-0.1.2.tgz",
+      "integrity": "sha512-h3GHp9BuPgY3X+WKWwJgTIl/h38KkcdU6JG28i1xdrlS8YXVi3V1YrhaZkjuvur97qZo8TMQjVXJorTf87LvfA=="
     },
-    "@types/chai-as-promised": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz",
-      "integrity": "sha512-FQnh1ohPXJELpKhzjuDkPLR2BZCAqed+a6xV4MI/T3XzHfd2FlarfUGUdZYgqYe8oxkYn0fchHEeHfHqdZ96sg==",
-      "requires": {
-        "@types/chai": "*"
-      }
+    "@types/cli-table": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.0.tgz",
+      "integrity": "sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ=="
     },
     "@types/concat-stream": {
       "version": "1.6.0",
@@ -7265,11 +7809,6 @@
         "@types/koa": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
-    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -7291,11 +7830,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
-    },
-    "@types/mocha": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/nedb": {
       "version": "1.8.11",
@@ -7381,28 +7915,6 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
-    },
-    "@types/sinon": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.11.tgz",
-      "integrity": "sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==",
-      "requires": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "@types/sinon-chai": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
-      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
-      "requires": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
-      }
-    },
-    "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
     },
     "@types/to-json-schema": {
       "version": "0.2.0",
@@ -7538,11 +8050,6 @@
           "optional": true
         }
       }
-    },
-    "@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
     },
     "@zondax/filecoin-signing-tools": {
       "version": "github:Digital-MOB-Filecoin/filecoin-signing-tools-js#8f8e92157cac2556d35cab866779e9a8ea8a4e25",
@@ -8445,6 +8952,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "asciichart": {
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/asciichart/-/asciichart-1.5.25.tgz",
+      "integrity": "sha512-PNxzXIPPOtWq8T7bgzBtk9cI2lgS4SJZthUHEiQ1aoIc3lNzGfUvIvo9LiAnq26TACo9t1/4qP6KTGAUbzX9Xg=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -8497,7 +9009,8 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -8620,6 +9133,7 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
       "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "optional": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -10338,6 +10852,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -10427,7 +10942,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "checkpoint-store": {
       "version": "1.1.0",
@@ -11109,6 +11625,11 @@
           }
         }
       }
+    },
+    "clear": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clear/-/clear-0.1.0.tgz",
+      "integrity": "sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw=="
     },
     "cli-boxes": {
       "version": "1.0.0",
@@ -11942,6 +12463,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -13522,6 +14044,55 @@
       "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
       "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg=="
     },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+          "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
     "ethereumjs-account": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
@@ -14606,59 +15177,6 @@
         }
       }
     },
-    "find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "requires": {
-        "micromatch": "^4.0.2"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
-        "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-          "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
-      }
-    },
     "first-chunk-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
@@ -15652,7 +16170,8 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -17770,11 +18289,6 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
-    "is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
-    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -18144,14 +18658,6 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
-    "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "requires": {
-        "is-docker": "^2.0.0"
-      }
-    },
     "is-yarn-global": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
@@ -18405,6 +18911,11 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
+    "js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18607,11 +19118,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsonrpc-lite": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jsonrpc-lite/-/jsonrpc-lite-2.2.0.tgz",
-      "integrity": "sha512-/cbbSxtZWs1O7R4tWqabrCM/t3N8qKUZMAg9IUqpPvUs6UyRvm6pCNYkskyKN/XU0UgffW+NY2ZRr8t0AknX7g=="
-    },
     "jsonschema": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.6.tgz",
@@ -18666,14 +19172,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-    },
-    "klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "requires": {
-        "graceful-fs": "^4.1.11"
-      }
     },
     "kleur": {
       "version": "3.0.3",
@@ -20158,6 +20656,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -20566,7 +21069,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "no-case": {
       "version": "2.3.2",
@@ -21500,15 +22004,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      }
-    },
     "opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -21934,81 +22429,6 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
-    "patch-package": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
-      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
-      "requires": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^2.4.2",
-        "cross-spawn": "^6.0.5",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
-        "is-ci": "^2.0.0",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.0",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^5.6.0",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "is-ci": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-          "requires": {
-            "ci-info": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "slash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-        }
-      }
-    },
     "path-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
@@ -22041,7 +22461,8 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -22065,7 +22486,8 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -24780,6 +25202,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -24787,7 +25210,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.4",
@@ -26472,6 +26896,52 @@
         "execa": "^0.7.0"
       }
     },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "supports-hyperlinks": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+          "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+          "requires": {
+            "has-flag": "^4.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+        }
+      }
+    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -26598,6 +27068,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -27293,7 +27764,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",
@@ -27953,6 +28425,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28049,6 +28533,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28076,6 +28572,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28105,6 +28613,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28235,6 +28755,44 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.4",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+              "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.12.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                  "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+                }
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
           }
         }
       }
@@ -28305,6 +28863,20 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-utils": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+          "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -28508,6 +29080,44 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.4",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+              "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.12.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                  "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+                }
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
           }
         }
       }
@@ -28602,6 +29212,44 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.4",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+              "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+              "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.12.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                  "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+                }
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
           }
         }
       }
@@ -28628,6 +29276,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28663,6 +29323,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28690,6 +29362,18 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
           }
         }
       }
@@ -28773,28 +29457,33 @@
       }
     },
     "web3-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
-      "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
       "requires": {
-        "bn.js": "4.11.8",
-        "eth-lib": "0.2.7",
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
-        "underscore": "1.9.1",
+        "randombytes": "^2.1.0",
         "utf8": "3.0.0"
       },
       "dependencies": {
-        "underscore": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
-        "utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
         }
       }
     },
@@ -28856,6 +29545,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
   "author": "POA network",
   "license": "GPLv3",
   "dependencies": {
-    "@opengsn/gsn": "^2.1.0",
+    "@opengsn/cli": "^2.2.2",
+    "@opengsn/contracts": "^2.2.2",
+    "@opengsn/provider": "^2.2.2",
     "array-flat-polyfill": "^1.0.1",
     "openzeppelin-solidity": "1.12.0",
     "truffle": "^5.3.2",
     "truffle-flattener": "^1.4.2",
-    "web3-provider-engine": "^14.0.6"
+    "web3-provider-engine": "^14.0.6",
+    "web3-utils": "^1.2.6"
   },
   "devDependencies": {
     "@codechecks/client": "^0.1.9",


### PR DESCRIPTION
## 1

The `postRelayedCall` function of the `TokenPaymaster` contract is public and allows anyone to call it. In this function the uniswap router is called and leftover funds are sent back to the user. Thus, this function modifies the state. Without an access control check that only allows the `RelayHub` to call it, an attacker can craft call data that will drain the ERC20 balance of the contract. Note that normally the contract is not supposed to have an ERC20 balance, however, this can change in situations as described in Anyone can steal GSN fees.

The `preRelayedCall` and `postRelayedCall` functions both have following comment in the official GSN `IPaymaster` class:

https://github.com/poanetwork/tokenbridge-contracts/blob/b3511bf0987bbfef661e28dd1a6fbe1735f90ac0/contracts/gsn/interfaces/IPaymaster.sol#L57

The `preRelayedCall` function does not modify state but it could still make sense to add an access control check.

## 2

The contracts use an outdated GSN interface in the definition of `IPaymaster`. In particular the following differences exist:
  * The function `getGasLimits` should now be called `getGasAndDataLimits()` and should return four instead of three values.
  * A `trustedForwarder` function should be implemented.

Furthermore, the `RelayData` struct has changed. As less context information is available the security guarantees are weaker.

----

The updates in this PR consist of:

1) Add `relayHubOnly` modifier for `postRelayedCall`
2) Update GSN Interface:
    1) Add `GasAndDataLimits` struct and `trustedForwarder` function in `IPaymaster` interface
    2) Update `RelayData` struct
3) Add `claimTokens` function in `TokenPaymaster`