### PR TITLE
Bump package and contracts interfaces version prior to 6.0.0-rc2

### DIFF
--- a/contracts/upgradeable_contracts/VersionableBridge.sol
+++ b/contracts/upgradeable_contracts/VersionableBridge.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 contract VersionableBridge {
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (6, 0, 0);
+        return (6, 1, 0);
     }
 
     /* solcov ignore next */

--- a/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/VersionableAMB.sol
@@ -17,6 +17,6 @@ contract VersionableAMB is VersionableBridge {
      * @return (major, minor, patch) version triple
      */
     function getBridgeInterfacesVersion() external pure returns (uint64 major, uint64 minor, uint64 patch) {
-        return (6, 1, 0);
+        return (6, 2, 0);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "6.0.0-rc2",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "6.0.0-rc1",
+  "version": "6.0.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "6.0.0-rc1",
+  "version": "6.0.0-rc2",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenbridge-contracts",
-  "version": "6.0.0-rc2",
+  "version": "6.0.0",
   "description": "Bridge",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The version has been updated to reflect the changes made for the latest security audit report under:
* #623 
* #624 
* #626
* #627
* #628 