### PR TITLE
Flatten the new xDai bridge contract

### DIFF
--- a/flatten.sh
+++ b/flatten.sh
@@ -27,6 +27,7 @@ ${FLATTENER} ${VALIDATOR_CONTRACTS_DIR}/RewardableValidators.sol > flats/validat
 echo "Flattening contracts related to erc-to-native bridge"
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_native/HomeBridgeErcToNative.sol > flats/erc20_to_native/HomeBridgeErcToNative_flat.sol
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_native/ForeignBridgeErcToNative.sol > flats/erc20_to_native/ForeignBridgeErcToNative_flat.sol
+${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_native/XDaiForeignBridge.sol > flats/erc20_to_native/XDaiForeignBridge.sol
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_native/FeeManagerErcToNative.sol > flats/erc20_to_native/FeeManagerErcToNative_flat.sol
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/erc20_to_native/FeeManagerErcToNativePOSDAO.sol > flats/erc20_to_native/FeeManagerErcToNativePOSDAO_flat.sol
 


### PR DESCRIPTION
It was found that the new xDai bridge contract is not flattened by the flatten script. So, the contract is not provided as part of the build artefacts. 