### PR TITLE
Update ERC677MultiBridgeToken.sol

### DIFF
--- a/contracts/ERC677MultiBridgeToken.sol
+++ b/contracts/ERC677MultiBridgeToken.sol
@@ -86,7 +86,7 @@ contract ERC677MultiBridgeToken is PermittableToken {
     */
     function bridgeList() external view returns (address[]) {
         address[] memory list = new address[](bridgeCount);
-        uint256 counter = 0;
+        uint256 counter;
         address nextBridge = bridgePointers[F_ADDR];
         require(nextBridge != address(0));
 
@@ -102,7 +102,7 @@ contract ERC677MultiBridgeToken is PermittableToken {
     }
 
     /**
-    * @dev Checks if given address is included into bridge contracts list
+    * @dev Checks if given address is included in bridge contracts list
     * @param _address bridge contract address
     * @return bool true, if given address is a known bridge contract 
     */


### PR DESCRIPTION
Made 2 changes in this particular file:

1st: changed `uint256 counter = 0;` to `uint256 counter;` , cuz default value of any variable if it's a `uint` used to be 0, It's just a waste of gas to initialize it with 0. Believe it or not, this do save some amount of gas.

2nd: `into` -> `in`, just a grammatical fix

Thanks!