### PR TITLE
Update AMBBridgeHelper.sol

### DIFF
--- a/contracts/helpers/AMBBridgeHelper.sol
+++ b/contracts/helpers/AMBBridgeHelper.sol
@@ -45,7 +45,7 @@ contract AMBBridgeHelper is Helper {
             mstore8(add(signatures, 32), signed)
         }
 
-        for (uint256 i = 0; i < signed; i++) {
+        for (uint256 i; i < signed; i++) {
             bytes memory sig = ambBridge.signature(msgHash, i);
             (bytes32 r, bytes32 s, uint8 v) = unpackSignature(sig);
             assembly {


### PR DESCRIPTION
Changed `uint256 i = 0` to `uint256 i`, there's no need to initialize some 'uint' variable to 0 cuz the default value already sets itself to 0. Saves some gas too.

Moreover, there's one more change we can make in this 'for' loop, that is changing `i++` to `++i`, if this change isn't messing up with the code logic, This is always beneficial to do so. Although, I haven't made this change, just a suggestion if you are down with it!